### PR TITLE
Refine Pebble workout haptics

### DIFF
--- a/pebble/src/c/main.c
+++ b/pebble/src/c/main.c
@@ -16,6 +16,8 @@ enum {
   KEY_TGT_KIND = 8,  // 0=none, 1=power(W), 2=pace (speed m/s), 3=HR(bpm)
   KEY_TGT_LO   = 9,  // uint16: W, bpm, or (m/s * 100)
   KEY_TGT_HI   = 10, // uint16: W, bpm, or (m/s * 100)
+  KEY_WORKOUT_OUTDOOR = 11, // uint8: target-band haptics enabled
+  KEY_WORKOUT_STEP = 12,    // uint16: expanded workout step index
 };
 
 typedef enum { UNITS_METRIC = 0, UNITS_IMPERIAL = 1 } Units;
@@ -51,6 +53,9 @@ static uint32_t s_last_dist_m;
 static TargetKind s_tgt_kind = TGT_NONE;
 static uint16_t   s_tgt_lo = 0;   // W or m/s*100 depending on kind
 static uint16_t   s_tgt_hi = 0;
+static bool       s_workout_outdoor = false;
+static bool       s_have_workout_step = false;
+static uint16_t   s_workout_step = 0;
 
 // ---------- UI: hero + grid ----------
 static TextLayer *s_hero_value;
@@ -412,7 +417,7 @@ static const char* zone_word(GColor zc){
 }
 
 static void maybe_haptic_transition(void) {
-  if (s_tgt_kind == TGT_NONE) return;
+  if (s_tgt_kind == TGT_NONE || !s_workout_outdoor) return;
   float lo = target_value(s_tgt_lo);
   float hi = target_value(s_tgt_hi);
   if (hi < lo) { float t=lo; lo=hi; hi=t; }
@@ -842,10 +847,24 @@ static void inbox_received(DictionaryIterator *iter, void *ctx) {
   bool target_changed = false;
   if ((t = dict_find(iter, KEY_TGT_KIND))) {
     s_tgt_kind = (TargetKind)t->value->uint8;
+    if (s_tgt_kind == TGT_NONE) s_have_workout_step = false;
     target_changed = true;
   }
   if ((t = dict_find(iter, KEY_TGT_LO))) { s_tgt_lo = t->value->uint16; target_changed = true; }
   if ((t = dict_find(iter, KEY_TGT_HI))) { s_tgt_hi = t->value->uint16; target_changed = true; }
+  if ((t = dict_find(iter, KEY_WORKOUT_OUTDOOR))) {
+    s_workout_outdoor = t->value->uint8 == 1;
+  }
+  if ((t = dict_find(iter, KEY_WORKOUT_STEP))) {
+    uint16_t next_step = t->value->uint16;
+    if (s_tgt_kind != TGT_NONE) {
+      if (s_have_workout_step && next_step != s_workout_step) vibes_short_pulse();
+      s_workout_step = next_step;
+      s_have_workout_step = true;
+    } else {
+      s_have_workout_step = false;
+    }
+  }
 
   if (target_changed) {
     s_view = (s_tgt_kind == TGT_NONE) ? VIEW_FREE : VIEW_WORKOUT;

--- a/src/fitness_tracker/ui_tracker.py
+++ b/src/fitness_tracker/ui_tracker.py
@@ -281,6 +281,10 @@ class TrackerPageUI:
             in_outdoor=in_outdoor,
             trainer=trainer,
         )
+        if self.app.pebble_bridge:
+            self.app.pebble_bridge.update(
+                workout_outdoor=in_outdoor == IndoorOutdoorEnum.outdoor,
+            )
         self._workout_paused = False
         self._workout_pause_started_monotonic = None
         self._push(self.workout_view, nice)
@@ -541,6 +545,8 @@ class TrackerPageUI:
         speed = self._target_values(step.speed_mps, step_progress)
         heart_rate = self._hr_target_values(step, step_progress)
 
+        if idx != self._active_step_index and self.app.pebble_bridge:
+            self.app.pebble_bridge.update(workout_step=idx)
         self._active_step_index = idx
 
         # target text

--- a/src/pebble_bridge/pebble_bridge.py
+++ b/src/pebble_bridge/pebble_bridge.py
@@ -37,6 +37,8 @@ KEY_POWER = 7
 KEY_TGT_KIND = 8
 KEY_TGT_LO = 9
 KEY_TGT_HI = 10
+KEY_WORKOUT_OUTDOOR = 11
+KEY_WORKOUT_STEP = 12
 
 # The EXACT widths the watchapp's C handler reads each key as
 # (t->value->uint8/uint16/uint32). Every backend pins to these so the watch
@@ -52,6 +54,8 @@ _KEY_WIDTH = {
     KEY_TGT_KIND: 8,
     KEY_TGT_LO: 16,
     KEY_TGT_HI: 16,
+    KEY_WORKOUT_OUTDOOR: 8,
+    KEY_WORKOUT_STEP: 16,
 }
 
 
@@ -273,6 +277,8 @@ class PebbleBridge:
         tgt_kind: int | None = None,
         tgt_lo: float | None = None,
         tgt_hi: float | None = None,
+        workout_outdoor: bool | None = None,
+        workout_step: int | None = None,
     ) -> None:
         """Update the latest metrics (None = no change)."""
         with self._lock:
@@ -301,6 +307,10 @@ class PebbleBridge:
             if tgt_hi is not None:
                 val = round(tgt_hi if tgt_kind in (1, 3) else (tgt_hi * 100.0))
                 self._state[KEY_TGT_HI] = val
+            if workout_outdoor is not None:
+                self._state[KEY_WORKOUT_OUTDOOR] = int(workout_outdoor)
+            if workout_step is not None:
+                self._state[KEY_WORKOUT_STEP] = int(workout_step)
 
     # --- internal ---
     def _connect(self) -> None:


### PR DESCRIPTION
Send workout environment and expanded step index through the Pebble bridge. Keep target-band transition vibrations enabled for outdoor workouts, while indoor and trainer workouts vibrate only when the active workout step changes.

Ignore initial step synchronization and free-run updates so they do not produce automatic haptics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for indoor and outdoor workout modes on the watch.
  - Outdoor workout haptic alerts can now be enabled or disabled.
  - The watch provides a brief haptic pulse when the active workout step changes.
  - Workout guidance now stays synchronized between the app and watch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->