### PR TITLE
Add free trainer target controls

### DIFF
--- a/src/fitness_tracker/recorder.py
+++ b/src/fitness_tracker/recorder.py
@@ -756,8 +756,10 @@ class Recorder:
             self._trainer_target_mode = target_mode
             self._pending_trainer_target = None
             self._erg_applied_target = None
-            if self._erg_retry_task and not self._erg_retry_task.done():
-                self._erg_retry_task.cancel()
+            previous_retry = self._erg_retry_task
+            self._erg_retry_task = None
+            if previous_retry and not previous_retry.done():
+                previous_retry.cancel()
 
     def _ensure_erg_retry_loop(
         self,

--- a/src/fitness_tracker/recorder.py
+++ b/src/fitness_tracker/recorder.py
@@ -58,6 +58,7 @@ class Recorder:
         ]
         | None = None,
         test_mode: bool = False,
+        trainer_supplied_hr: bool = False,
     ):
         logger.debug(f"Initializing Recorder with sport_type {sport_type}")
         logger.debug(f"HR sensor: name={hr_name}, address={hr_address}")
@@ -100,6 +101,7 @@ class Recorder:
         # Sensors
         self.hr_name: str | None = hr_name
         self.hr_address: str | None = hr_address
+        self.trainer_supplied_hr = trainer_supplied_hr
         self.hr_device: BLEDevice | None = None
         self.speed_name: str | None = speed_name
         self.speed_address: str | None = speed_address
@@ -426,6 +428,15 @@ class Recorder:
             update={"timestamp_ms": delta_ms, "distance_m": adjusted_distance_m},
         )
 
+        if self.trainer_supplied_hr and sample.heart_rate_bpm is not None:
+            self.hr_connected = True
+            self._handle_hr_sample(
+                HeartRateSample(
+                    timestamp_ms=sample.timestamp_ms,
+                    heart_rate_bpm=sample.heart_rate_bpm,
+                ),
+            )
+
         # Update UI
         GLib.idle_add(self.on_sample, cleaned_sample)
 
@@ -655,6 +666,8 @@ class Recorder:
         self.distance_connected = connected
 
         if not connected:
+            if self.trainer_supplied_hr:
+                self.hr_connected = False
             # reset erg watts on disconnect so it applies immediately on reconnect
             self._erg_applied_target = None
 

--- a/src/fitness_tracker/recorder.py
+++ b/src/fitness_tracker/recorder.py
@@ -87,6 +87,7 @@ class Recorder:
         self.activity_id = None
         self._start_ms = None
         self._pending_trainer_target: int | float | None = None
+        self._trainer_target_mode: Literal["Power", "Resistance", "Speed"] | None = None
         self._erg_retry_task: Future | None = None
         self._erg_applied_target: int | float | None = None
 
@@ -405,10 +406,12 @@ class Recorder:
             sample.target_power is not None
             and self._pending_trainer_target is None
             and self._erg_applied_target != sample.target_power
+            and self._trainer_target_mode != "Resistance"
         ):
             logger.debug(
                 f"Trainer target power {sample.target_power} watts differs from applied {self._erg_applied_target} watts, scheduling update"
             )
+            self._select_trainer_target_mode("Power")
             self._pending_trainer_target = sample.target_power
             self._ensure_erg_retry_loop("Power")
 
@@ -698,6 +701,8 @@ class Recorder:
             self._erg_safeguard_saved_watts: int = watts
             return
 
+        self._select_trainer_target_mode("Power")
+
         # Store intent
         self._pending_trainer_target = watts
 
@@ -710,6 +715,7 @@ class Recorder:
     def set_target_resistance(self, resistance: float) -> None:
         """Set target resistance on the trainer if supported."""
         logger.debug(f"Trying to set target resistance to {resistance} watts")
+        self._select_trainer_target_mode("Resistance")
 
         # Store intent
         self._pending_trainer_target = resistance
@@ -720,7 +726,32 @@ class Recorder:
 
         self._ensure_erg_retry_loop("Resistance")
 
-    def _ensure_erg_retry_loop(self, target_mode: Literal["Power", "Resistance"]) -> None:
+    def set_target_speed(self, speed_kmh: float) -> None:
+        """Set target treadmill speed in kilometers per hour."""
+        logger.debug(f"Trying to set target speed to {speed_kmh} km/h")
+        self._select_trainer_target_mode("Speed")
+        self._pending_trainer_target = speed_kmh
+        if self._erg_applied_target != speed_kmh:
+            self._erg_applied_target = None
+        self._ensure_erg_retry_loop("Speed")
+
+    def _select_trainer_target_mode(
+        self,
+        target_mode: Literal["Power", "Resistance", "Speed"],
+    ) -> None:
+        if self._trainer_target_mode != target_mode:
+            self._trainer_target_mode = target_mode
+            self._pending_trainer_target = None
+            self._erg_applied_target = None
+            if self._erg_retry_task and not self._erg_retry_task.done():
+                self._erg_retry_task.cancel()
+
+    def _ensure_erg_retry_loop(
+        self,
+        target_mode: Literal["Power", "Resistance", "Speed"],
+    ) -> None:
+        self._select_trainer_target_mode(target_mode)
+
         if self.test_mode:
             return
 
@@ -732,9 +763,15 @@ class Recorder:
             self.loop,
         )
 
-    async def _erg_retry_loop(self, target_mode: Literal["Power", "Resistance"]) -> None:
+    async def _erg_retry_loop(
+        self,
+        target_mode: Literal["Power", "Resistance", "Speed"],
+    ) -> None:
         retry_interval = 2.0
         while True:
+            if self._trainer_target_mode != target_mode:
+                return
+
             # Read the current pending target at the start of each iteration.
             target = self._pending_trainer_target
             if target is None:
@@ -768,6 +805,12 @@ class Recorder:
                             self._pending_trainer_target = None
                             self._erg_applied_target = result
 
+                            return
+                    elif target_mode == "Speed":
+                        result = await mux.set_target_speed(float(target))
+                        if self._pending_trainer_target == result:
+                            self._pending_trainer_target = None
+                            self._erg_applied_target = result
                             return
 
                 except Exception as e:

--- a/src/fitness_tracker/recorder.py
+++ b/src/fitness_tracker/recorder.py
@@ -406,7 +406,7 @@ class Recorder:
             sample.target_power is not None
             and self._pending_trainer_target is None
             and self._erg_applied_target != sample.target_power
-            and self._trainer_target_mode != "Resistance"
+            and self._trainer_target_mode in (None, "Power")
         ):
             logger.debug(
                 f"Trainer target power {sample.target_power} watts differs from applied {self._erg_applied_target} watts, scheduling update"
@@ -792,7 +792,10 @@ class Recorder:
                         result = await mux.set_target_power(int(target))
                         # Only clear the pending value if it wasn't updated
                         # while the await was in-flight.
-                        if self._pending_trainer_target == result:
+                        if (
+                            self._trainer_target_mode == target_mode
+                            and self._pending_trainer_target == result
+                        ):
                             self._pending_trainer_target = None
                             self._erg_applied_target = result
 
@@ -801,14 +804,20 @@ class Recorder:
                         result = await mux.set_target_resistance(float(target))
                         # Only clear the pending value if it wasn't updated
                         # while the await was in-flight.
-                        if self._pending_trainer_target == result:
+                        if (
+                            self._trainer_target_mode == target_mode
+                            and self._pending_trainer_target == result
+                        ):
                             self._pending_trainer_target = None
                             self._erg_applied_target = result
 
                             return
                     elif target_mode == "Speed":
                         result = await mux.set_target_speed(float(target))
-                        if self._pending_trainer_target == result:
+                        if (
+                            self._trainer_target_mode == target_mode
+                            and self._pending_trainer_target == result
+                        ):
                             self._pending_trainer_target = None
                             self._erg_applied_target = result
                             return
@@ -819,6 +828,9 @@ class Recorder:
             await asyncio.sleep(retry_interval)
 
     def _update_erg_safeguard(self, timestamp_ms: int, power_watts: int | None):
+        if self._trainer_target_mode != "Power" and self.sport_type != SportTypesEnum.biking:
+            return
+
         window = 3000
         power_threshold = 60
 

--- a/src/fitness_tracker/ui.py
+++ b/src/fitness_tracker/ui.py
@@ -19,7 +19,12 @@ from xdg_base_dirs import (
 from fitness_tracker.database import SportTypesEnum
 from fitness_tracker.recorder import Recorder
 from fitness_tracker.ui_history import HistoryPageUI
-from fitness_tracker.ui_settings import AppSettings, SettingsPageUI, fallback_settings
+from fitness_tracker.ui_settings import (
+    TRAINER_SUPPLIED_HR_LABEL,
+    AppSettings,
+    SettingsPageUI,
+    fallback_settings,
+)
 from fitness_tracker.ui_tracker import TrackerPageUI
 
 gi.require_versions({"Gtk": "4.0", "Adw": "1"})
@@ -35,8 +40,9 @@ UI_THREAD_WAIT_TIMEOUT_S = 5.0
 @dataclass(frozen=True)
 class SensorProfile:
     # Common HRM (optional)
-    hr_name: str = ""
-    hr_address: str = ""
+    hr_name: str | None = None
+    hr_address: str | None = None
+    trainer_supplied_hr: bool = False
 
     # “speed/cadence/power” addresses (meaning depends on profile)
     speed_name: str = ""
@@ -197,9 +203,17 @@ class FitnessAppUI(Adw.Application):
         if trainer:
             if sport_type == SportTypesEnum.running:
                 logger.debug("Using trainer running profile")
+                trainer_supplied_hr = (
+                    self.app_settings.trainer_running.hr_name == TRAINER_SUPPLIED_HR_LABEL
+                )
                 return SensorProfile(
-                    hr_name=self.app_settings.trainer_running.hr_name,
-                    hr_address=self.app_settings.trainer_running.hr_address,
+                    hr_name=None
+                    if trainer_supplied_hr
+                    else self.app_settings.trainer_running.hr_name,
+                    hr_address=None
+                    if trainer_supplied_hr
+                    else self.app_settings.trainer_running.hr_address,
+                    trainer_supplied_hr=trainer_supplied_hr,
                     speed_name="",  # trainer doesn't use speed/cad/power sensors
                     speed_address="",
                     cadence_name="",
@@ -212,9 +226,17 @@ class FitnessAppUI(Adw.Application):
                 )
             if sport_type == SportTypesEnum.biking:
                 logger.debug("Using trainer biking profile")
+                trainer_supplied_hr = (
+                    self.app_settings.trainer_cycling.hr_name == TRAINER_SUPPLIED_HR_LABEL
+                )
                 return SensorProfile(
-                    hr_name=self.app_settings.trainer_cycling.hr_name,
-                    hr_address=self.app_settings.trainer_cycling.hr_address,
+                    hr_name=None
+                    if trainer_supplied_hr
+                    else self.app_settings.trainer_cycling.hr_name,
+                    hr_address=None
+                    if trainer_supplied_hr
+                    else self.app_settings.trainer_cycling.hr_address,
+                    trainer_supplied_hr=trainer_supplied_hr,
                     speed_name="",  # trainer doesn't use speed/cad/power sensors
                     speed_address="",
                     cadence_name="",
@@ -270,6 +292,11 @@ class FitnessAppUI(Adw.Application):
                 if current and getattr(current, "sport_type", None) == sport_type:
                     same = True
                     same &= (desired.hr_address or "") == (getattr(current, "hr_address", "") or "")
+                    same &= desired.trainer_supplied_hr == getattr(
+                        current,
+                        "trainer_supplied_hr",
+                        False,
+                    )
                     same &= (desired.speed_address or "") == (
                         getattr(current, "speed_address", "") or ""
                     )
@@ -326,6 +353,7 @@ class FitnessAppUI(Adw.Application):
                         trainer_name=desired.trainer_name,
                         trainer_address=desired.trainer_address,
                         trainer_machine_type=desired.trainer_machine_type,
+                        trainer_supplied_hr=desired.trainer_supplied_hr,
                         on_error=self.show_toast,
                         test_mode=self.test_mode,
                     )

--- a/src/fitness_tracker/ui_free_run.py
+++ b/src/fitness_tracker/ui_free_run.py
@@ -8,6 +8,7 @@ from matplotlib.figure import Figure
 
 from fitness_tracker.database import SportTypesEnum
 from fitness_tracker.ui_mode import IndoorOutdoorEnum
+from fitness_tracker.ui_trainer_control import TrainerTargetControl
 from fitness_tracker.ui_workout import InclineControl
 
 gi.require_versions({"Gtk": "4.0", "Adw": "1"})
@@ -87,106 +88,6 @@ class _Timer(Gtk.Frame):
 
     def set_text(self, text: str) -> None:
         self.lbl.set_text(text)
-
-
-class TrainerTargetControl(Gtk.Frame):
-    """Sport-specific free trainer target control."""
-
-    BIKE_MODES = {
-        "Power": {"minimum": 0, "maximum": 2000, "step": 5, "unit": "W"},
-        "Resistance": {"minimum": 0, "maximum": 100, "step": 1, "unit": "%"},
-    }
-    RUN_MODES = {
-        "Speed": {"minimum": 0.0, "maximum": 15.0, "step": 0.1, "unit": "mph"},
-    }
-
-    def __init__(self, on_change, sport_type: SportTypesEnum) -> None:
-        super().__init__()
-        self._on_change = on_change
-        self.MODES = self.BIKE_MODES if sport_type == SportTypesEnum.biking else self.RUN_MODES
-        self._mode = "Power" if sport_type == SportTypesEnum.biking else "Speed"
-        self._values = {"Power": 100, "Resistance": 2, "Speed": 3.0}
-
-        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-        for margin in ("top", "bottom", "start", "end"):
-            getattr(outer, f"set_margin_{margin}")(8)
-
-        if sport_type == SportTypesEnum.biking:
-            mode_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-            mode_row.set_homogeneous(True)
-            mode_row.set_hexpand(True)
-
-            self._power_mode_btn = Gtk.Button(label="Power")
-            self._power_mode_btn.set_size_request(-1, 56)
-            self._power_mode_btn.add_css_class("suggested-action")
-
-            self._resistance_mode_btn = Gtk.Button(label="Resistance")
-            self._resistance_mode_btn.set_size_request(-1, 56)
-
-            self._power_mode_btn.connect("clicked", self._on_mode_clicked, "Power")
-            self._resistance_mode_btn.connect("clicked", self._on_mode_clicked, "Resistance")
-            mode_row.append(self._power_mode_btn)
-            mode_row.append(self._resistance_mode_btn)
-            outer.append(mode_row)
-        else:
-            title = Gtk.Label(label="Speed")
-            title.add_css_class("caption")
-            outer.append(title)
-
-        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self._btn_down = Gtk.Button(label="-")
-        self._btn_down.add_css_class("destructive-action")
-        self._btn_down.set_hexpand(True)
-        self._btn_down.set_size_request(-1, 72)
-        self._btn_down.get_child().add_css_class("title-1")
-        self._btn_down.connect("clicked", lambda *_: self._change(-1))
-
-        self._lbl_value = Gtk.Label()
-        self._lbl_value.add_css_class("title-1")
-        self._lbl_value.add_css_class("numeric")
-        self._lbl_value.set_hexpand(True)
-        self._lbl_value.set_xalign(0.5)
-
-        self._btn_up = Gtk.Button(label="+")
-        self._btn_up.add_css_class("suggested-action")
-        self._btn_up.set_hexpand(True)
-        self._btn_up.set_size_request(-1, 72)
-        self._btn_up.get_child().add_css_class("title-1")
-        self._btn_up.connect("clicked", lambda *_: self._change(1))
-
-        row.append(self._btn_down)
-        row.append(self._lbl_value)
-        row.append(self._btn_up)
-        outer.append(row)
-        self.set_child(outer)
-        self._refresh()
-
-    def _change(self, direction: int) -> None:
-        config = self.MODES[self._mode]
-        value = self._values[self._mode] + direction * config["step"]
-        value = max(config["minimum"], min(config["maximum"], value))
-        self._values[self._mode] = round(value, 1) if self._mode == "Speed" else value
-        self._refresh()
-        self._on_change(self._mode, self._values[self._mode])
-
-    def _on_mode_clicked(self, _button, mode: str) -> None:
-        if mode == self._mode:
-            return
-        self._mode = mode
-        self._power_mode_btn.set_css_classes(["suggested-action"] if mode == "Power" else [])
-        self._resistance_mode_btn.set_css_classes(
-            ["suggested-action"] if mode == "Resistance" else []
-        )
-        self._refresh()
-        self._on_change(self._mode, self._values[self._mode])
-
-    def _refresh(self) -> None:
-        config = self.MODES[self._mode]
-        value = self._values[self._mode]
-        value_text = f"{value:.1f}" if self._mode == "Speed" else str(value)
-        self._lbl_value.set_text(f"{value_text} {config['unit']}")
-        self._btn_down.set_sensitive(value > config["minimum"])
-        self._btn_up.set_sensitive(value < config["maximum"])
 
 
 class FreeRunView(Gtk.Box):

--- a/src/fitness_tracker/ui_free_run.py
+++ b/src/fitness_tracker/ui_free_run.py
@@ -89,6 +89,106 @@ class _Timer(Gtk.Frame):
         self.lbl.set_text(text)
 
 
+class TrainerTargetControl(Gtk.Frame):
+    """Sport-specific free trainer target control."""
+
+    BIKE_MODES = {
+        "Power": {"minimum": 0, "maximum": 2000, "step": 5, "unit": "W"},
+        "Resistance": {"minimum": 0, "maximum": 100, "step": 1, "unit": "%"},
+    }
+    RUN_MODES = {
+        "Speed": {"minimum": 0.0, "maximum": 15.0, "step": 0.1, "unit": "mph"},
+    }
+
+    def __init__(self, on_change, sport_type: SportTypesEnum) -> None:
+        super().__init__()
+        self._on_change = on_change
+        self.MODES = self.BIKE_MODES if sport_type == SportTypesEnum.biking else self.RUN_MODES
+        self._mode = "Power" if sport_type == SportTypesEnum.biking else "Speed"
+        self._values = {"Power": 100, "Resistance": 2, "Speed": 3.0}
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        for margin in ("top", "bottom", "start", "end"):
+            getattr(outer, f"set_margin_{margin}")(8)
+
+        if sport_type == SportTypesEnum.biking:
+            mode_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            mode_row.set_homogeneous(True)
+            mode_row.set_hexpand(True)
+
+            self._power_mode_btn = Gtk.Button(label="Power")
+            self._power_mode_btn.set_size_request(-1, 56)
+            self._power_mode_btn.add_css_class("suggested-action")
+
+            self._resistance_mode_btn = Gtk.Button(label="Resistance")
+            self._resistance_mode_btn.set_size_request(-1, 56)
+
+            self._power_mode_btn.connect("clicked", self._on_mode_clicked, "Power")
+            self._resistance_mode_btn.connect("clicked", self._on_mode_clicked, "Resistance")
+            mode_row.append(self._power_mode_btn)
+            mode_row.append(self._resistance_mode_btn)
+            outer.append(mode_row)
+        else:
+            title = Gtk.Label(label="Speed")
+            title.add_css_class("caption")
+            outer.append(title)
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self._btn_down = Gtk.Button(label="-")
+        self._btn_down.add_css_class("destructive-action")
+        self._btn_down.set_hexpand(True)
+        self._btn_down.set_size_request(-1, 72)
+        self._btn_down.get_child().add_css_class("title-1")
+        self._btn_down.connect("clicked", lambda *_: self._change(-1))
+
+        self._lbl_value = Gtk.Label()
+        self._lbl_value.add_css_class("title-1")
+        self._lbl_value.add_css_class("numeric")
+        self._lbl_value.set_hexpand(True)
+        self._lbl_value.set_xalign(0.5)
+
+        self._btn_up = Gtk.Button(label="+")
+        self._btn_up.add_css_class("suggested-action")
+        self._btn_up.set_hexpand(True)
+        self._btn_up.set_size_request(-1, 72)
+        self._btn_up.get_child().add_css_class("title-1")
+        self._btn_up.connect("clicked", lambda *_: self._change(1))
+
+        row.append(self._btn_down)
+        row.append(self._lbl_value)
+        row.append(self._btn_up)
+        outer.append(row)
+        self.set_child(outer)
+        self._refresh()
+
+    def _change(self, direction: int) -> None:
+        config = self.MODES[self._mode]
+        value = self._values[self._mode] + direction * config["step"]
+        value = max(config["minimum"], min(config["maximum"], value))
+        self._values[self._mode] = round(value, 1) if self._mode == "Speed" else value
+        self._refresh()
+        self._on_change(self._mode, self._values[self._mode])
+
+    def _on_mode_clicked(self, _button, mode: str) -> None:
+        if mode == self._mode:
+            return
+        self._mode = mode
+        self._power_mode_btn.set_css_classes(["suggested-action"] if mode == "Power" else [])
+        self._resistance_mode_btn.set_css_classes(
+            ["suggested-action"] if mode == "Resistance" else []
+        )
+        self._refresh()
+        self._on_change(self._mode, self._values[self._mode])
+
+    def _refresh(self) -> None:
+        config = self.MODES[self._mode]
+        value = self._values[self._mode]
+        value_text = f"{value:.1f}" if self._mode == "Speed" else str(value)
+        self._lbl_value.set_text(f"{value_text} {config['unit']}")
+        self._btn_down.set_sensitive(value > config["minimum"])
+        self._btn_up.set_sensitive(value < config["maximum"])
+
+
 class FreeRunView(Gtk.Box):
     """
     The full dashboard (timer, metric cards, live HR/Power chart) as a reusable widget.
@@ -168,6 +268,13 @@ class FreeRunView(Gtk.Box):
             and not self.trainer
         ):
             grid.attach(self.incline_control, 0, 4, 2, 1)
+
+        self.trainer_target_control = TrainerTargetControl(
+            self._on_trainer_target_change,
+            self.sport_type,
+        )
+        if self.trainer:
+            grid.attach(self.trainer_target_control, 0, 4, 2, 1)
 
         self.append(grid)
 
@@ -281,6 +388,14 @@ class FreeRunView(Gtk.Box):
     def set_incline_callback(self, cb) -> None:
         """Register a callable(percent: float) to fire on every incline change."""
         self._incline_cb = cb
+
+    def _on_trainer_target_change(self, mode: str, value: int | float) -> None:
+        if callable(getattr(self, "_trainer_target_cb", None)):
+            self._trainer_target_cb(mode, value)
+
+    def set_trainer_target_callback(self, cb) -> None:
+        """Register a callable(mode, value) for trainer target changes."""
+        self._trainer_target_cb = cb
 
     # ---- style helpers
     def _style_hr_axis(self) -> None:

--- a/src/fitness_tracker/ui_settings.py
+++ b/src/fitness_tracker/ui_settings.py
@@ -31,6 +31,7 @@ gi.require_versions({"Gtk": "4.0", "Adw": "1"})
 from gi.repository import Adw, GLib, Gtk  # noqa: E402  # ty:ignore[unresolved-import]
 
 NONE_LABEL = "None"
+TRAINER_SUPPLIED_HR_LABEL = "Trainer supplied"
 
 
 class PersonalSettings(BaseModel):
@@ -987,16 +988,28 @@ class SettingsPageUI:
 
         self._combo_set_items_with_none(
             self.trainer_running_hr_combo,
-            [self.app.app_settings.trainer_running.hr_name]
-            if self.app.app_settings.trainer_running.hr_name
-            else [],
+            [
+                TRAINER_SUPPLIED_HR_LABEL,
+                *(
+                    [self.app.app_settings.trainer_running.hr_name]
+                    if self.app.app_settings.trainer_running.hr_name
+                    and self.app.app_settings.trainer_running.hr_name != TRAINER_SUPPLIED_HR_LABEL
+                    else []
+                ),
+            ],
             self.app.app_settings.trainer_running.hr_name,
         )
         self._combo_set_items_with_none(
             self.trainer_cycling_hr_combo,
-            [self.app.app_settings.trainer_cycling.hr_name]
-            if self.app.app_settings.trainer_cycling.hr_name
-            else [],
+            [
+                TRAINER_SUPPLIED_HR_LABEL,
+                *(
+                    [self.app.app_settings.trainer_cycling.hr_name]
+                    if self.app.app_settings.trainer_cycling.hr_name
+                    and self.app.app_settings.trainer_cycling.hr_name != TRAINER_SUPPLIED_HR_LABEL
+                    else []
+                ),
+            ],
             self.app.app_settings.trainer_cycling.hr_name,
         )
         self.trainer_running_hr_map = (
@@ -1080,7 +1093,7 @@ class SettingsPageUI:
         async def _scan():
             devices = await discover_heart_rate_devices(scan_timeout=5.0)
             mapping = {d.name: d.address for d in devices if d.name}
-            names = sorted(mapping.keys())
+            names = [TRAINER_SUPPLIED_HR_LABEL, *sorted(mapping.keys())]
 
             def _apply():
                 self.hr_spinner.stop()
@@ -1565,6 +1578,9 @@ class SettingsPageUI:
             if sel == NONE_LABEL or not sel:
                 self.app.app_settings.trainer_running.hr_name = None
                 self.app.app_settings.trainer_running.hr_address = None
+            elif sel == TRAINER_SUPPLIED_HR_LABEL:
+                self.app.app_settings.trainer_running.hr_name = TRAINER_SUPPLIED_HR_LABEL
+                self.app.app_settings.trainer_running.hr_address = None
             else:
                 self.app.app_settings.trainer_running.hr_name = sel
                 self.app.app_settings.trainer_running.hr_address = self.trainer_running_hr_map.get(
@@ -1593,6 +1609,9 @@ class SettingsPageUI:
             sel = self.trainer_cycling_hr_combo.get_active_text()
             if sel == NONE_LABEL or not sel:
                 self.app.app_settings.trainer_cycling.hr_name = None
+                self.app.app_settings.trainer_cycling.hr_address = None
+            elif sel == TRAINER_SUPPLIED_HR_LABEL:
+                self.app.app_settings.trainer_cycling.hr_name = TRAINER_SUPPLIED_HR_LABEL
                 self.app.app_settings.trainer_cycling.hr_address = None
             else:
                 self.app.app_settings.trainer_cycling.hr_name = sel

--- a/src/fitness_tracker/ui_tracker.py
+++ b/src/fitness_tracker/ui_tracker.py
@@ -16,7 +16,11 @@ from fitness_tracker.database import SportTypesEnum
 from fitness_tracker.ui_free_run import FreeRunView
 from fitness_tracker.ui_mode import IndoorOutdoorEnum, ModeSelectView
 from fitness_tracker.ui_workout import WorkoutView
-from fitness_tracker.workouts import apply_target_bias
+from fitness_tracker.workouts import (
+    apply_target_bias,
+    has_external_trainer_hr_sensor,
+    has_heart_rate_targets,
+)
 
 gi.require_versions({"Gtk": "4.0", "Adw": "1"})
 from gi.repository import Adw, GLib  # noqa: E402  # ty:ignore[unresolved-import]
@@ -274,6 +278,12 @@ class TrackerPageUI:
 
         raw = self._workout.name if self._workout else "Workout"
         nice = pretty_workout_name(raw)
+        show_trainer_target_control = (
+            trainer
+            and sport_type == SportTypesEnum.biking
+            and has_heart_rate_targets(self._workout_steps)
+            and has_external_trainer_hr_sensor(self.app.recorder)
+        )
         self.workout_view = WorkoutView(
             app=self.app,
             sport_type=sport_type,
@@ -284,6 +294,7 @@ class TrackerPageUI:
             on_start_record=self._on_workout_start_pause_clicked,
             in_outdoor=in_outdoor,
             trainer=trainer,
+            show_trainer_target_control=show_trainer_target_control,
         )
         if self.app.pebble_bridge:
             self.app.pebble_bridge.update(
@@ -296,6 +307,7 @@ class TrackerPageUI:
 
         self.workout_view.set_incline_callback(self._on_incline_changed)
         self.workout_view.set_bias_callback(self._on_bias_changed)
+        self.workout_view.set_trainer_target_callback(self._on_trainer_target_changed)
         if self.app.recorder and self.app.recorder.incline_percent is not None:
             self.workout_view.incline_control.set_value(self.app.recorder.incline_percent)
 

--- a/src/fitness_tracker/ui_tracker.py
+++ b/src/fitness_tracker/ui_tracker.py
@@ -222,6 +222,7 @@ class TrackerPageUI:
         view.btn_stop.connect("clicked", lambda *_: self._stop_run_and_back())
         view.btn_start.connect("clicked", lambda *_: self._begin_run_now())
         view.set_incline_callback(self._on_incline_changed)
+        view.set_trainer_target_callback(self._on_trainer_target_changed)
         if self.app.recorder and self.app.recorder.incline_percent is not None:
             view.incline_control.set_value(self.app.recorder.incline_percent)
         return view
@@ -1079,3 +1080,13 @@ class TrackerPageUI:
         self._erg_last_set_watts = None
         self._erg_last_set_ts = 0.0
         self._update_workout_guidance(self._elapsed_display_s if self._running else 0)
+
+    def _on_trainer_target_changed(self, mode: str, value: int | float) -> None:
+        if not self.app.recorder:
+            return
+        if mode == "Power":
+            self.app.recorder.set_target_power(int(value))
+        elif mode == "Resistance":
+            self.app.recorder.set_target_resistance(value)
+        else:
+            self.app.recorder.set_target_speed(round(value * 1.60934, 3))

--- a/src/fitness_tracker/ui_tracker.py
+++ b/src/fitness_tracker/ui_tracker.py
@@ -18,7 +18,6 @@ from fitness_tracker.ui_mode import IndoorOutdoorEnum, ModeSelectView
 from fitness_tracker.ui_workout import WorkoutView
 from fitness_tracker.workouts import (
     apply_target_bias,
-    has_external_trainer_hr_sensor,
     has_heart_rate_targets,
 )
 
@@ -45,6 +44,10 @@ class TrackerPageUI:
         self._last_ms: int | None = None
         self._erg_last_set_watts: int | None = None
         self._erg_last_set_ts: float = 0.0
+        self._speed_last_set_kmh: float | None = None
+        self._speed_last_set_ts: float = 0.0
+        self._workout_trainer_control_mode = "Bias"
+        self._workout_manual_speed_kmh: float | None = None
         self._workout_bias_percent: int = 0
 
         # lifecycle flags
@@ -137,6 +140,8 @@ class TrackerPageUI:
         self._workout = workout
         self._manual_offset_s = 0.0
         self._workout_bias_percent = 0
+        self._workout_trainer_control_mode = "Bias"
+        self._workout_manual_speed_kmh = None
         self._show_workout_page(sport_type=sport_type, in_outdoor=in_outdoor, trainer=trainer)
 
     def _show_free_from_mode(
@@ -161,6 +166,14 @@ class TrackerPageUI:
             # Reset erg throttle so target power re-applies immediately
             self._erg_last_set_watts = None
             self._erg_last_set_ts = 0.0
+            self._speed_last_set_kmh = None
+            self._speed_last_set_ts = 0.0
+            if (
+                self._workout_trainer_control_mode == "Speed"
+                and self._workout_manual_speed_kmh is not None
+                and self.app.recorder
+            ):
+                self.app.recorder.set_target_speed(self._workout_manual_speed_kmh)
             if self.workout_view:
                 self.workout_view.set_paused(False)
         else:
@@ -169,8 +182,12 @@ class TrackerPageUI:
             self._workout_paused = True
             # Drop ERG target so user isn't fighting the trainer
             if self.app.recorder and self.app.recorder.trainer_mux:
-                self.app.recorder.set_target_power(0)
+                if self.workout_view and self.workout_view.sport_type == SportTypesEnum.running:
+                    self.app.recorder.set_target_speed(0)
+                else:
+                    self.app.recorder.set_target_power(0)
                 self._erg_last_set_watts = None
+                self._speed_last_set_kmh = None
             if self.workout_view:
                 self.workout_view.set_paused(True)
 
@@ -282,7 +299,8 @@ class TrackerPageUI:
             trainer
             and sport_type == SportTypesEnum.biking
             and has_heart_rate_targets(self._workout_steps)
-            and has_external_trainer_hr_sensor(self.app.recorder)
+            and self.app.recorder
+            and not self.app.recorder.trainer_supplied_hr
         )
         self.workout_view = WorkoutView(
             app=self.app,
@@ -333,6 +351,8 @@ class TrackerPageUI:
         self._last_ms = 0
         self._erg_last_set_watts = None
         self._erg_last_set_ts = 0.0
+        self._speed_last_set_kmh = None
+        self._speed_last_set_ts = 0.0
 
         if self.app.recorder:
             self.app.recorder.start_recording()
@@ -364,14 +384,27 @@ class TrackerPageUI:
             GLib.source_remove(self._test_source)
             self._test_source = None
 
+        trainer_sport_type = (
+            self.workout_view.sport_type
+            if self.workout_view
+            else self.free_view.sport_type
+            if self.free_view
+            else None
+        )
+
         # release page refs and go home
         self.free_view = None
         self.workout_view = None
 
         self._erg_last_set_watts = None
         self._erg_last_set_ts = 0.0
+        self._speed_last_set_kmh = None
+        self._speed_last_set_ts = 0.0
         if self.app.recorder and self.app.recorder.trainer_mux:
-            self.app.recorder.set_target_power(0)
+            if trainer_sport_type == SportTypesEnum.running:
+                self.app.recorder.set_target_speed(0)
+            else:
+                self.app.recorder.set_target_power(0)
 
         self._pop_to_mode()
 
@@ -665,6 +698,21 @@ class TrackerPageUI:
                     tgt_lo=speed_lo,
                     tgt_hi=speed_hi,
                 )
+            if (
+                self.app.recorder
+                and self.app.recorder.trainer_mux
+                and self.workout_view.trainer
+                and self.workout_view.sport_type == SportTypesEnum.running
+                and self._workout_trainer_control_mode == "Bias"
+            ):
+                target_kmh = round(speed_mid * 3.6, 1)
+                now = time.monotonic()
+                if self._speed_last_set_kmh != target_kmh and (
+                    self._speed_last_set_kmh is None or now - self._speed_last_set_ts > 2.0
+                ):
+                    self.app.recorder.set_target_speed(target_kmh)
+                    self._speed_last_set_kmh = target_kmh
+                    self._speed_last_set_ts = now
         elif heart_rate:
             hr_lo, hr_mid, hr_hi = heart_rate
             self.workout_view.set_gauge_hr(
@@ -1088,17 +1136,23 @@ class TrackerPageUI:
 
     def _on_bias_changed(self, percent: int) -> None:
         """Apply trainer workout difficulty changes immediately."""
+        self._workout_trainer_control_mode = "Bias"
         self._workout_bias_percent = percent
         self._erg_last_set_watts = None
         self._erg_last_set_ts = 0.0
+        self._speed_last_set_kmh = None
+        self._speed_last_set_ts = 0.0
         self._update_workout_guidance(self._elapsed_display_s if self._running else 0)
 
     def _on_trainer_target_changed(self, mode: str, value: int | float) -> None:
         if not self.app.recorder:
             return
+        self._workout_trainer_control_mode = mode
         if mode == "Power":
             self.app.recorder.set_target_power(int(value))
         elif mode == "Resistance":
             self.app.recorder.set_target_resistance(value)
         else:
-            self.app.recorder.set_target_speed(round(value * 1.60934, 3))
+            self._speed_last_set_kmh = None
+            self._workout_manual_speed_kmh = round(value * 1.60934, 3)
+            self.app.recorder.set_target_speed(self._workout_manual_speed_kmh)

--- a/src/fitness_tracker/ui_trainer_control.py
+++ b/src/fitness_tracker/ui_trainer_control.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import gi
+
+from fitness_tracker.database import SportTypesEnum
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # noqa: E402  # ty:ignore[unresolved-import]
+
+
+class TrainerTargetControl(Gtk.Frame):
+    """Sport-specific trainer target control."""
+
+    BIKE_MODES = {
+        "Power": {"minimum": 0, "maximum": 2000, "step": 5, "unit": "W"},
+        "Resistance": {"minimum": 0, "maximum": 100, "step": 1, "unit": "%"},
+    }
+    RUN_MODES = {
+        "Speed": {"minimum": 0.0, "maximum": 15.0, "step": 0.1, "unit": "mph"},
+    }
+
+    def __init__(self, on_change, sport_type: SportTypesEnum) -> None:
+        super().__init__()
+        self._on_change = on_change
+        self.MODES = self.BIKE_MODES if sport_type == SportTypesEnum.biking else self.RUN_MODES
+        self._mode = "Power" if sport_type == SportTypesEnum.biking else "Speed"
+        self._values = {"Power": 100, "Resistance": 2, "Speed": 3.0}
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        for margin in ("top", "bottom", "start", "end"):
+            getattr(outer, f"set_margin_{margin}")(8)
+
+        if sport_type == SportTypesEnum.biking:
+            mode_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            mode_row.set_homogeneous(True)
+            mode_row.set_hexpand(True)
+
+            self._power_mode_btn = Gtk.Button(label="Power")
+            self._power_mode_btn.set_size_request(-1, 56)
+            self._power_mode_btn.add_css_class("suggested-action")
+
+            self._resistance_mode_btn = Gtk.Button(label="Resistance")
+            self._resistance_mode_btn.set_size_request(-1, 56)
+
+            self._power_mode_btn.connect("clicked", self._on_mode_clicked, "Power")
+            self._resistance_mode_btn.connect("clicked", self._on_mode_clicked, "Resistance")
+            mode_row.append(self._power_mode_btn)
+            mode_row.append(self._resistance_mode_btn)
+            outer.append(mode_row)
+        else:
+            title = Gtk.Label(label="Speed")
+            title.add_css_class("caption")
+            outer.append(title)
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self._btn_down = Gtk.Button(label="-")
+        self._btn_down.add_css_class("destructive-action")
+        self._btn_down.set_hexpand(True)
+        self._btn_down.set_size_request(-1, 72)
+        self._btn_down.get_child().add_css_class("title-1")
+        self._btn_down.connect("clicked", lambda *_: self._change(-1))
+
+        self._lbl_value = Gtk.Label()
+        self._lbl_value.add_css_class("title-1")
+        self._lbl_value.add_css_class("numeric")
+        self._lbl_value.set_hexpand(True)
+        self._lbl_value.set_xalign(0.5)
+
+        self._btn_up = Gtk.Button(label="+")
+        self._btn_up.add_css_class("suggested-action")
+        self._btn_up.set_hexpand(True)
+        self._btn_up.set_size_request(-1, 72)
+        self._btn_up.get_child().add_css_class("title-1")
+        self._btn_up.connect("clicked", lambda *_: self._change(1))
+
+        row.append(self._btn_down)
+        row.append(self._lbl_value)
+        row.append(self._btn_up)
+        outer.append(row)
+        self.set_child(outer)
+        self._refresh()
+
+    def _change(self, direction: int) -> None:
+        config = self.MODES[self._mode]
+        value = self._values[self._mode] + direction * config["step"]
+        value = max(config["minimum"], min(config["maximum"], value))
+        self._values[self._mode] = round(value, 1) if self._mode == "Speed" else value
+        self._refresh()
+        self._on_change(self._mode, self._values[self._mode])
+
+    def _on_mode_clicked(self, _button, mode: str) -> None:
+        if mode == self._mode:
+            return
+        self._mode = mode
+        self._power_mode_btn.set_css_classes(["suggested-action"] if mode == "Power" else [])
+        self._resistance_mode_btn.set_css_classes(
+            ["suggested-action"] if mode == "Resistance" else [],
+        )
+        self._refresh()
+        self._on_change(self._mode, self._values[self._mode])
+
+    def _refresh(self) -> None:
+        config = self.MODES[self._mode]
+        value = self._values[self._mode]
+        value_text = f"{value:.1f}" if self._mode == "Speed" else str(value)
+        self._lbl_value.set_text(f"{value_text} {config['unit']}")
+        self._btn_down.set_sensitive(value > config["minimum"])
+        self._btn_up.set_sensitive(value < config["maximum"])

--- a/src/fitness_tracker/ui_trainer_control.py
+++ b/src/fitness_tracker/ui_trainer_control.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 import gi
 
 from fitness_tracker.database import SportTypesEnum
@@ -11,7 +13,7 @@ from gi.repository import Gtk  # noqa: E402  # ty:ignore[unresolved-import]
 class TrainerTargetControl(Gtk.Frame):
     """Touch-friendly control for selecting and adjusting trainer targets."""
 
-    MODE_CONFIGS = {
+    MODE_CONFIGS: ClassVar[dict[str, dict[str, int | float | str]]] = {
         "Bias": {"minimum": -50, "maximum": 50, "step": 5, "unit": "%"},
         "Power": {"minimum": 0, "maximum": 2000, "step": 5, "unit": "W"},
         "Resistance": {"minimum": 0, "maximum": 100, "step": 1, "unit": "%"},

--- a/src/fitness_tracker/ui_trainer_control.py
+++ b/src/fitness_tracker/ui_trainer_control.py
@@ -9,46 +9,52 @@ from gi.repository import Gtk  # noqa: E402  # ty:ignore[unresolved-import]
 
 
 class TrainerTargetControl(Gtk.Frame):
-    """Sport-specific trainer target control."""
+    """Touch-friendly control for selecting and adjusting trainer targets."""
 
-    BIKE_MODES = {
+    MODE_CONFIGS = {
+        "Bias": {"minimum": -50, "maximum": 50, "step": 5, "unit": "%"},
         "Power": {"minimum": 0, "maximum": 2000, "step": 5, "unit": "W"},
         "Resistance": {"minimum": 0, "maximum": 100, "step": 1, "unit": "%"},
-    }
-    RUN_MODES = {
         "Speed": {"minimum": 0.0, "maximum": 15.0, "step": 0.1, "unit": "mph"},
     }
 
-    def __init__(self, on_change, sport_type: SportTypesEnum) -> None:
+    def __init__(
+        self,
+        on_change,
+        sport_type: SportTypesEnum,
+        *,
+        available_modes: tuple[str, ...] | None = None,
+    ) -> None:
         super().__init__()
         self._on_change = on_change
-        self.MODES = self.BIKE_MODES if sport_type == SportTypesEnum.biking else self.RUN_MODES
-        self._mode = "Power" if sport_type == SportTypesEnum.biking else "Speed"
-        self._values = {"Power": 100, "Resistance": 2, "Speed": 3.0}
+        if available_modes is None:
+            available_modes = (
+                ("Power", "Resistance") if sport_type == SportTypesEnum.biking else ("Speed",)
+            )
+        self.MODES = {mode: self.MODE_CONFIGS[mode] for mode in available_modes}
+        self._mode = available_modes[0]
+        self._values = {"Bias": 0, "Power": 100, "Resistance": 2, "Speed": 3.0}
+        self._mode_buttons = {}
 
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         for margin in ("top", "bottom", "start", "end"):
             getattr(outer, f"set_margin_{margin}")(8)
 
-        if sport_type == SportTypesEnum.biking:
+        if len(available_modes) > 1:
             mode_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
             mode_row.set_homogeneous(True)
             mode_row.set_hexpand(True)
-
-            self._power_mode_btn = Gtk.Button(label="Power")
-            self._power_mode_btn.set_size_request(-1, 56)
-            self._power_mode_btn.add_css_class("suggested-action")
-
-            self._resistance_mode_btn = Gtk.Button(label="Resistance")
-            self._resistance_mode_btn.set_size_request(-1, 56)
-
-            self._power_mode_btn.connect("clicked", self._on_mode_clicked, "Power")
-            self._resistance_mode_btn.connect("clicked", self._on_mode_clicked, "Resistance")
-            mode_row.append(self._power_mode_btn)
-            mode_row.append(self._resistance_mode_btn)
+            for mode in available_modes:
+                button = Gtk.Button(label=mode)
+                button.set_size_request(-1, 56)
+                if mode == self._mode:
+                    button.add_css_class("suggested-action")
+                button.connect("clicked", self._on_mode_clicked, mode)
+                self._mode_buttons[mode] = button
+                mode_row.append(button)
             outer.append(mode_row)
         else:
-            title = Gtk.Label(label="Speed")
+            title = Gtk.Label(label=self._mode)
             title.add_css_class("caption")
             outer.append(title)
 
@@ -92,10 +98,8 @@ class TrainerTargetControl(Gtk.Frame):
         if mode == self._mode:
             return
         self._mode = mode
-        self._power_mode_btn.set_css_classes(["suggested-action"] if mode == "Power" else [])
-        self._resistance_mode_btn.set_css_classes(
-            ["suggested-action"] if mode == "Resistance" else [],
-        )
+        for button_mode, button in self._mode_buttons.items():
+            button.set_css_classes(["suggested-action"] if button_mode == mode else [])
         self._refresh()
         self._on_change(self._mode, self._values[self._mode])
 

--- a/src/fitness_tracker/ui_workout.py
+++ b/src/fitness_tracker/ui_workout.py
@@ -6,6 +6,7 @@ import gi
 
 from fitness_tracker.database import SportTypesEnum
 from fitness_tracker.ui_mode import IndoorOutdoorEnum
+from fitness_tracker.ui_trainer_control import TrainerTargetControl
 
 gi.require_versions({"Gtk": "4.0", "Adw": "1"})
 from gi.repository import Adw, Gdk, Gtk, Pango, PangoCairo  # noqa: E402, I001  # ty:ignore[unresolved-import]
@@ -491,6 +492,7 @@ class WorkoutView(Gtk.Box):
         on_start_record,
         in_outdoor: IndoorOutdoorEnum = IndoorOutdoorEnum.indoor,
         trainer: bool = False,
+        show_trainer_target_control: bool = False,
     ) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=6)
         self.app = app
@@ -617,6 +619,13 @@ class WorkoutView(Gtk.Box):
         if self.trainer:
             content.append(self.bias_control)
 
+        if show_trainer_target_control:
+            self.trainer_target_control = TrainerTargetControl(
+                self._on_trainer_target_change,
+                self.sport_type,
+            )
+            content.append(self.trainer_target_control)
+
         # Buttons
         self.btn_prev = Gtk.Button.new_with_label("◀︎ Prev")
         self.btn_prev.add_css_class("pill")
@@ -712,6 +721,13 @@ class WorkoutView(Gtk.Box):
 
     def set_bias_callback(self, cb) -> None:
         self._bias_cb = cb
+
+    def _on_trainer_target_change(self, mode: str, value: int | float) -> None:
+        if callable(getattr(self, "_trainer_target_cb", None)):
+            self._trainer_target_cb(mode, value)
+
+    def set_trainer_target_callback(self, cb) -> None:
+        self._trainer_target_cb = cb
 
     # Timers (optional helpers)
     def set_elapsed_text(self, text: str) -> None:

--- a/src/fitness_tracker/ui_workout.py
+++ b/src/fitness_tracker/ui_workout.py
@@ -93,72 +93,6 @@ class InclineControl(Gtk.Frame):
         self._refresh()
 
 
-class BiasControl(Gtk.Frame):
-    """Large-touch trainer workout difficulty control."""
-
-    MIN_PCT = -50
-    MAX_PCT = 50
-    STEP = 5
-
-    def __init__(self, on_change, initial_value: int = 0) -> None:
-        super().__init__()
-        self._value = initial_value
-        self._on_change = on_change
-
-        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-        for margin in ("top", "bottom", "start", "end"):
-            getattr(outer, f"set_margin_{margin}")(8)
-
-        title = Gtk.Label(label="Workout Bias")
-        title.add_css_class("caption")
-        title.set_xalign(0.5)
-        outer.append(title)
-
-        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self._btn_down = Gtk.Button(label="-")
-        self._btn_down.add_css_class("destructive-action")
-        self._btn_down.set_hexpand(True)
-        self._btn_down.set_size_request(-1, 72)
-        self._btn_down.get_child().add_css_class("title-1")
-        self._btn_down.connect("clicked", lambda *_: self._change(-self.STEP))
-
-        self._lbl_value = Gtk.Label()
-        self._lbl_value.add_css_class("title-1")
-        self._lbl_value.add_css_class("numeric")
-        self._lbl_value.set_xalign(0.5)
-        self._lbl_value.set_width_chars(7)
-        self._lbl_value.set_hexpand(True)
-        self._lbl_value.set_valign(Gtk.Align.CENTER)
-
-        self._btn_up = Gtk.Button(label="+")
-        self._btn_up.add_css_class("suggested-action")
-        self._btn_up.set_hexpand(True)
-        self._btn_up.set_size_request(-1, 72)
-        self._btn_up.get_child().add_css_class("title-1")
-        self._btn_up.connect("clicked", lambda *_: self._change(self.STEP))
-
-        row.append(self._btn_down)
-        row.append(self._lbl_value)
-        row.append(self._btn_up)
-        outer.append(row)
-        self.set_child(outer)
-        self._refresh()
-
-    def _change(self, delta: int) -> None:
-        self._value = max(self.MIN_PCT, min(self.MAX_PCT, self._value + delta))
-        self._refresh()
-        self._on_change(self._value)
-
-    def _refresh(self) -> None:
-        self._lbl_value.set_text(f"{self._value:+d}%")
-        self._btn_down.set_sensitive(self._value > self.MIN_PCT)
-        self._btn_up.set_sensitive(self._value < self.MAX_PCT)
-
-    def set_value(self, value: int) -> None:
-        self._value = max(self.MIN_PCT, min(self.MAX_PCT, int(value)))
-        self._refresh()
-
-
 # --------- TargetGauge: semi-circle with target band + needle --------- #
 class TargetGauge(Gtk.DrawingArea):
     """
@@ -614,15 +548,17 @@ class WorkoutView(Gtk.Box):
         ):
             content.append(self.incline_control)
 
-        self.bias_control = BiasControl(on_change=self._on_bias_change)
-        self.bias_control.set_hexpand(True)
         if self.trainer:
-            content.append(self.bias_control)
-
-        if show_trainer_target_control:
+            if self.sport_type == SportTypesEnum.running:
+                modes = ("Bias", "Speed")
+            elif show_trainer_target_control:
+                modes = ("Bias", "Power", "Resistance")
+            else:
+                modes = ("Bias",)
             self.trainer_target_control = TrainerTargetControl(
                 self._on_trainer_target_change,
                 self.sport_type,
+                available_modes=modes,
             )
             content.append(self.trainer_target_control)
 
@@ -723,6 +659,9 @@ class WorkoutView(Gtk.Box):
         self._bias_cb = cb
 
     def _on_trainer_target_change(self, mode: str, value: int | float) -> None:
+        if mode == "Bias":
+            self._on_bias_change(int(value))
+            return
         if callable(getattr(self, "_trainer_target_cb", None)):
             self._trainer_target_cb(mode, value)
 

--- a/src/fitness_tracker/workouts.py
+++ b/src/fitness_tracker/workouts.py
@@ -8,6 +8,28 @@ from pathlib import Path
 AUTO_SUBDIRS = ("intervals_icu",)
 
 
+def has_heart_rate_targets(steps) -> bool:
+    """Return whether any workout step contains a supported heart-rate target."""
+    fields = (
+        "heart_rate_bpm",
+        "heart_rate_percent_max",
+        "heart_rate_percent_lthr",
+        "heart_rate_zone",
+    )
+    return any(any(getattr(step, field, None) is not None for field in fields) for step in steps)
+
+
+def has_external_trainer_hr_sensor(recorder) -> bool:
+    """Return whether the configured trainer HR source is a separate device."""
+    if not recorder:
+        return False
+    if recorder.hr_address and recorder.trainer_address:
+        return recorder.hr_address != recorder.trainer_address
+    if recorder.hr_name and recorder.trainer_name:
+        return recorder.hr_name != recorder.trainer_name
+    return False
+
+
 def apply_target_bias(
     values: tuple[float, float, float] | None,
     percent: int,

--- a/src/fitness_tracker/workouts.py
+++ b/src/fitness_tracker/workouts.py
@@ -19,17 +19,6 @@ def has_heart_rate_targets(steps) -> bool:
     return any(any(getattr(step, field, None) is not None for field in fields) for step in steps)
 
 
-def has_external_trainer_hr_sensor(recorder) -> bool:
-    """Return whether the configured trainer HR source is a separate device."""
-    if not recorder:
-        return False
-    if recorder.hr_address and recorder.trainer_address:
-        return recorder.hr_address != recorder.trainer_address
-    if recorder.hr_name and recorder.trainer_name:
-        return recorder.hr_name != recorder.trainer_name
-    return False
-
-
 def apply_target_bias(
     values: tuple[float, float, float] | None,
     percent: int,

--- a/tests/test_recorder_lifecycle.py
+++ b/tests/test_recorder_lifecycle.py
@@ -4,6 +4,7 @@ import asyncio
 import threading
 import types
 import unittest
+from unittest.mock import Mock
 
 # Recorder only needs these modules for UI callbacks. Stub them so its
 # event-loop lifecycle can be tested on headless systems without GTK typelibs.
@@ -13,11 +14,13 @@ import gi.repository
 gi.require_versions = lambda _versions: None
 gi.repository.Adw = types.SimpleNamespace()
 
+from bleaksport import TrainerSample
+
 from fitness_tracker.database import SportTypesEnum
 from fitness_tracker.recorder import Recorder
 
 
-def _make_recorder(*, test_mode=False):
+def _make_recorder(*, test_mode=False, trainer_supplied_hr=False):
     return Recorder(
         weight_kg=None,
         sport_type=SportTypesEnum.running,
@@ -34,7 +37,9 @@ def _make_recorder(*, test_mode=False):
         trainer_address=None,
         trainer_machine_type=None,
         on_error=lambda _msg: None,
+        on_sample_update=lambda _sample: None,
         test_mode=test_mode,
+        trainer_supplied_hr=trainer_supplied_hr,
     )
 
 
@@ -164,6 +169,24 @@ class RecorderLifecycleTests(unittest.TestCase):
         self.assertEqual(recorder._pending_trainer_target, 8.5)
         self.assertEqual(recorder._erg_safeguard_saved_watts, 250)
 
+        recorder.shutdown()
+
+    def test_trainer_supplied_heart_rate_is_forwarded_and_persisted(self):
+        recorder = _make_recorder(test_mode=True, trainer_supplied_hr=True)
+        recorder._recording = True
+        recorder.activity_id = 1
+        recorder.db.insert_heart_rate = Mock()
+        recorder.db.insert_running_metrics = Mock()
+
+        recorder.inject_test_sample(
+            TrainerSample(timestamp_ms=1000, heart_rate_bpm=152),
+        )
+
+        self.assertTrue(recorder.hr_connected)
+        self.assertEqual(list(recorder._bpm_history), [152])
+        recorder.db.insert_heart_rate.assert_called_once_with(1, 0, 152, None, None)
+
+        recorder._recording = False
         recorder.shutdown()
 
 

--- a/tests/test_recorder_lifecycle.py
+++ b/tests/test_recorder_lifecycle.py
@@ -103,6 +103,69 @@ class RecorderLifecycleTests(unittest.TestCase):
 
         recorder.shutdown()
 
+    def test_in_flight_power_result_does_not_clear_new_resistance_target(self):
+        recorder = _make_recorder()
+        command_started = asyncio.Event()
+        resistance_started = asyncio.Event()
+        hold_resistance = asyncio.Event()
+
+        class TrainerMuxMock:
+            is_connected = True
+
+            async def set_target_power(self, watts):
+                command_started.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    return watts
+
+            async def set_target_resistance(self, resistance):
+                resistance_started.set()
+                await hold_resistance.wait()
+                return resistance
+
+        async def exercise_race():
+            recorder.loop.close()
+            recorder.loop = asyncio.get_running_loop()
+            recorder.trainer_mux = TrainerMuxMock()
+            recorder._erg_disabled = False
+            recorder.set_target_power(5)
+            await command_started.wait()
+
+            recorder.set_target_resistance(5)
+            await resistance_started.wait()
+
+            self.assertEqual(recorder._trainer_target_mode, "Resistance")
+            self.assertEqual(recorder._pending_trainer_target, 5)
+
+        asyncio.run(exercise_race())
+        recorder.shutdown()
+
+    def test_speed_target_is_ignored_by_erg_safeguard(self):
+        recorder = _make_recorder(test_mode=True)
+        recorder.set_target_speed(8.5)
+        recorder._erg_disabled = False
+
+        recorder._update_erg_safeguard(0, 0)
+        recorder._update_erg_safeguard(4000, 0)
+
+        self.assertFalse(recorder._erg_disabled)
+        self.assertEqual(recorder._trainer_target_mode, "Speed")
+        self.assertEqual(recorder._pending_trainer_target, 8.5)
+        self.assertIsNone(recorder._erg_safeguard_saved_watts)
+
+        recorder._erg_disabled = True
+        recorder._erg_safeguard_saved_watts = 250
+        recorder._update_erg_safeguard(8000, 100)
+        recorder._update_erg_safeguard(12000, 100)
+
+        self.assertTrue(recorder._erg_disabled)
+        self.assertEqual(recorder._trainer_target_mode, "Speed")
+        self.assertEqual(recorder._pending_trainer_target, 8.5)
+        self.assertEqual(recorder._erg_safeguard_saved_watts, 250)
+
+        recorder.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_recorder_lifecycle.py
+++ b/tests/test_recorder_lifecycle.py
@@ -72,6 +72,37 @@ class RecorderLifecycleTests(unittest.TestCase):
         self.assertTrue(recorder.shutdown())
         self.assertTrue(recorder.loop.is_closed())
 
+    def test_trainer_target_can_switch_between_power_and_resistance(self):
+        recorder = _make_recorder(test_mode=True)
+        recorder._erg_disabled = False
+
+        recorder.set_target_power(150)
+        self.assertEqual(recorder._trainer_target_mode, "Power")
+        self.assertEqual(recorder._pending_trainer_target, 150)
+
+        recorder.set_target_resistance(25)
+        self.assertEqual(recorder._trainer_target_mode, "Resistance")
+        self.assertEqual(recorder._pending_trainer_target, 25)
+
+        recorder.set_target_speed(8.5)
+        self.assertEqual(recorder._trainer_target_mode, "Speed")
+        self.assertEqual(recorder._pending_trainer_target, 8.5)
+
+        recorder.shutdown()
+
+    def test_erg_lockout_keeps_recovery_resistance_when_power_target_arrives(self):
+        recorder = _make_recorder(test_mode=True)
+        recorder.set_target_resistance(5)
+        recorder._erg_disabled = True
+
+        recorder.set_target_power(250)
+
+        self.assertEqual(recorder._trainer_target_mode, "Resistance")
+        self.assertEqual(recorder._pending_trainer_target, 5)
+        self.assertEqual(recorder._erg_safeguard_saved_watts, 250)
+
+        recorder.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui_sensor_lifecycle.py
+++ b/tests/test_ui_sensor_lifecycle.py
@@ -44,6 +44,7 @@ sys.modules[ui_history.__name__] = ui_history
 ui_settings = types.ModuleType("fitness_tracker.ui_settings")
 ui_settings.AppSettings = object
 ui_settings.SettingsPageUI = object
+ui_settings.TRAINER_SUPPLIED_HR_LABEL = "Trainer supplied"
 ui_settings.fallback_settings = lambda _path: None
 sys.modules[ui_settings.__name__] = ui_settings
 

--- a/tests/test_workout_bias.py
+++ b/tests/test_workout_bias.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 
 from fitness_tracker.workouts import (
     apply_target_bias,
-    has_external_trainer_hr_sensor,
     has_heart_rate_targets,
 )
 
@@ -25,25 +24,7 @@ def test_workout_bias_preserves_fractional_speed_to_tenths() -> None:
     assert values == (3.5, 3.5, 3.5)
 
 
-def test_detects_heart_rate_target_and_external_trainer_hr_sensor() -> None:
+def test_detects_heart_rate_target() -> None:
     steps = [SimpleNamespace(heart_rate_bpm=SimpleNamespace(value=150))]
-    recorder = SimpleNamespace(
-        hr_address="AA:BB",
-        trainer_address="CC:DD",
-        hr_name="Chest strap",
-        trainer_name="Smart bike",
-    )
 
     assert has_heart_rate_targets(steps)
-    assert has_external_trainer_hr_sensor(recorder)
-
-
-def test_trainer_itself_is_not_an_external_hr_sensor() -> None:
-    recorder = SimpleNamespace(
-        hr_address="AA:BB",
-        trainer_address="AA:BB",
-        hr_name="Smart bike",
-        trainer_name="Smart bike",
-    )
-
-    assert not has_external_trainer_hr_sensor(recorder)

--- a/tests/test_workout_bias.py
+++ b/tests/test_workout_bias.py
@@ -1,4 +1,10 @@
-from fitness_tracker.workouts import apply_target_bias
+from types import SimpleNamespace
+
+from fitness_tracker.workouts import (
+    apply_target_bias,
+    has_external_trainer_hr_sensor,
+    has_heart_rate_targets,
+)
 
 
 def test_workout_bias_scales_full_power_target_range() -> None:
@@ -17,3 +23,27 @@ def test_workout_bias_preserves_fractional_speed_to_tenths() -> None:
     values = apply_target_bias((3.3, 3.3, 3.3), 5, decimal_places=1)
 
     assert values == (3.5, 3.5, 3.5)
+
+
+def test_detects_heart_rate_target_and_external_trainer_hr_sensor() -> None:
+    steps = [SimpleNamespace(heart_rate_bpm=SimpleNamespace(value=150))]
+    recorder = SimpleNamespace(
+        hr_address="AA:BB",
+        trainer_address="CC:DD",
+        hr_name="Chest strap",
+        trainer_name="Smart bike",
+    )
+
+    assert has_heart_rate_targets(steps)
+    assert has_external_trainer_hr_sensor(recorder)
+
+
+def test_trainer_itself_is_not_an_external_hr_sensor() -> None:
+    recorder = SimpleNamespace(
+        hr_address="AA:BB",
+        trainer_address="AA:BB",
+        hr_name="Smart bike",
+        trainer_name="Smart bike",
+    )
+
+    assert not has_external_trainer_hr_sensor(recorder)


### PR DESCRIPTION
Add touch-friendly, sport-specific controls for free trainer sessions. Cycling supports live power and resistance switching, while running provides treadmill speed adjustment in MPH with FTMS conversion.

Track trainer command modes so stale retries are cancelled during mode changes, and preserve the ERG death-spiral safeguard by retaining recovery resistance while power targets are locked out. Add lifecycle regression coverage for mode switching and safety behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trainer-supplied heart-rate support in sensor profiles and settings, forwarding HR samples into recorder updates.
  * Introduced touch-friendly trainer target controls (Bias/Power/Resistance/Speed) in free run and workout UIs, with immediate recorder updates via callback wiring.
  * Added helper to detect heart-rate targets in workout steps.
* **Bug Fixes**
  * Improved trainer target retry orchestration to prevent stale-mode updates and incorrect pending/applied clearing; refined ERG safeguards to apply only in Power mode (with biking exceptions).
* **Tests**
  * Extended lifecycle and UI-related tests for HR forwarding/persistence, mode switching, async overlap edge cases, and speed-target safeguard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->