### PR TITLE
Improve workout transition handling

### DIFF
--- a/src/fitness_tracker/ui.py
+++ b/src/fitness_tracker/ui.py
@@ -29,7 +29,7 @@ from fitness_tracker.ui_tracker import TrackerPageUI
 
 gi.require_versions({"Gtk": "4.0", "Adw": "1"})
 
-from gi.repository import Adw, Gdk, GLib, Gtk  # noqa: E402  # ty:ignore[unresolved-import]
+from gi.repository import Adw, Gdk, Gio, GLib, Gtk  # noqa: E402  # ty:ignore[unresolved-import]
 
 if TYPE_CHECKING:
     import datetime
@@ -153,6 +153,34 @@ class FitnessAppUI(Adw.Application):
         # Create and display a toast on our overlay
         toast = Adw.Toast.new(message)
         self.toast_overlay.add_toast(toast)
+
+    def show_workout_step_notification(
+        self,
+        step_number: int,
+        step_count: int,
+        target_text: str,
+        *,
+        announce: bool = True,
+    ) -> None:
+        """Update step integrations and optionally announce a workout step change."""
+        if self.pebble_bridge:
+            self.pebble_bridge.update(workout_step=step_number - 1)
+        if not announce:
+            return
+
+        title = f"Workout step {step_number} of {step_count}"
+        self.show_toast(f"{title}: {target_text}")
+        notification = Gio.Notification.new(title)
+        notification.set_body(target_text)
+        self.send_notification("workout-step-change", notification)
+
+    def show_workout_complete_notification(self) -> None:
+        """Show in-app and desktop notifications when a workout completes."""
+        message = "✅ Workout complete. Continuing in Free Run…"
+        self.show_toast(message)
+        notification = Gio.Notification.new("Workout complete")
+        notification.set_body("Continuing in Free Run")
+        self.send_notification("workout-complete", notification)
 
     def apply_pebble_settings(self) -> None:
         if self.pebble_bridge:

--- a/src/fitness_tracker/ui_tracker.py
+++ b/src/fitness_tracker/ui_tracker.py
@@ -253,6 +253,11 @@ class TrackerPageUI:
         in_outdoor: IndoorOutdoorEnum = IndoorOutdoorEnum.indoor,
         trainer: bool = False,
     ) -> None:
+        self._workout = None
+        self._workout_steps = []
+        self._manual_offset_s = 0.0
+        self._active_step_index = -1
+
         # Reconfigure recorder for this activity *before* preview/status updates.
         self.app.apply_sensor_settings(sport_type=sport_type, trainer=trainer)
         if self.app.pebble_bridge:
@@ -607,8 +612,7 @@ class TrackerPageUI:
         speed = self._biased_target_values(step.speed_mps, step_progress, decimal_places=1)
         heart_rate = self._hr_target_values(step, step_progress)
 
-        if idx != self._active_step_index and self.app.pebble_bridge:
-            self.app.pebble_bridge.update(workout_step=idx)
+        step_changed = idx != self._active_step_index
         self._active_step_index = idx
 
         # target text
@@ -623,6 +627,14 @@ class TrackerPageUI:
             tgt_txt = f"Target: {b} - {a} /mi"
         elif heart_rate:
             tgt_txt = f"Target: {round(heart_rate[0])} - {round(heart_rate[2])} bpm"
+
+        if step_changed:
+            self.app.show_workout_step_notification(
+                idx + 1,
+                len(self._workout_steps),
+                tgt_txt,
+                announce=self._running,
+            )
 
         # next preview
         nxt_text = "Next: —"
@@ -790,7 +802,7 @@ class TrackerPageUI:
                 self.update_metric_statuses()
             # Clear reference to the workout view so it is not updated off-screen
             self.workout_view = None
-            self.app.show_toast("✅ Workout complete. Continuing in Free Run…")
+            self.app.show_workout_complete_notification()
 
             if self.app.pebble_bridge:
                 self.app.pebble_bridge.update(tgt_kind=TGT_NONE)
@@ -939,7 +951,8 @@ class TrackerPageUI:
         self._sim_target_mph = None
 
         if self._workout:
-            t_s = (t_ms / 1000.0 if self._running else 0.0) + self._manual_offset_s
+            raw_t_s = (t_ms / 1000.0 if self._running else 0.0) + self._manual_offset_s
+            t_s = max(0.0, raw_t_s) if math.isfinite(raw_t_s) else 0.0
             idx, step = self._workout.get_step_at(t_s)
             if not step or idx is None:
                 return True

--- a/tests/test_ui_sensor_lifecycle.py
+++ b/tests/test_ui_sensor_lifecycle.py
@@ -28,8 +28,22 @@ class _GLib:
         return 1
 
 
+class _Notification:
+    def __init__(self, title):
+        self.title = title
+        self.body = None
+
+    @classmethod
+    def new(cls, title):
+        return cls(title)
+
+    def set_body(self, body):
+        self.body = body
+
+
 gi.repository.Adw = types.SimpleNamespace(Application=_Application)
 gi.repository.Gdk = types.SimpleNamespace()
+gi.repository.Gio = types.SimpleNamespace(Notification=_Notification)
 gi.repository.GLib = _GLib
 gi.repository.Gtk = types.SimpleNamespace()
 
@@ -105,6 +119,58 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
 
     def _run_idle(self):
         _GLib.callbacks.get(timeout=2)()
+
+    def test_workout_step_notification_uses_toast_and_desktop_notification(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        toasts = []
+        notifications = []
+        pebble_steps = []
+        app.show_toast = toasts.append
+        app.send_notification = lambda notification_id, notification: notifications.append(
+            (notification_id, notification),
+        )
+        app.pebble_bridge = types.SimpleNamespace(
+            update=lambda **values: pebble_steps.append(values["workout_step"]),
+        )
+
+        app.show_workout_step_notification(2, 5, "Target: 150 - 175 W")
+
+        self.assertEqual(pebble_steps, [1])
+        self.assertEqual(toasts, ["Workout step 2 of 5: Target: 150 - 175 W"])
+        self.assertEqual(notifications[0][0], "workout-step-change")
+        self.assertEqual(notifications[0][1].title, "Workout step 2 of 5")
+        self.assertEqual(notifications[0][1].body, "Target: 150 - 175 W")
+
+    def test_workout_step_preview_only_updates_pebble(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        pebble_steps = []
+        app.pebble_bridge = types.SimpleNamespace(
+            update=lambda **values: pebble_steps.append(values["workout_step"]),
+        )
+        app.show_toast = lambda _message: self.fail("Preview should not show a toast")
+        app.send_notification = lambda *_args: self.fail(
+            "Preview should not send a desktop notification",
+        )
+
+        app.show_workout_step_notification(1, 5, "Target: 100 W", announce=False)
+
+        self.assertEqual(pebble_steps, [0])
+
+    def test_workout_complete_uses_toast_and_desktop_notification(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        toasts = []
+        notifications = []
+        app.show_toast = toasts.append
+        app.send_notification = lambda notification_id, notification: notifications.append(
+            (notification_id, notification),
+        )
+
+        app.show_workout_complete_notification()
+
+        self.assertEqual(toasts, ["✅ Workout complete. Continuing in Free Run…"])
+        self.assertEqual(notifications[0][0], "workout-complete")
+        self.assertEqual(notifications[0][1].title, "Workout complete")
+        self.assertEqual(notifications[0][1].body, "Continuing in Free Run")
 
     def test_app_shutdown_waits_for_profile_apply_lock(self):
         app = self._make_app()


### PR DESCRIPTION
Announce workout step changes and completion through in-app and desktop notifications while centralizing Pebble step synchronization. Reset trainer target caches across heart-rate transitions, clear stale workout state before free run, and add notification lifecycle coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workout step notifications through both in-app toasts and desktop notifications.
  * Added workout completion notifications through both in-app toasts and desktop notifications.
  * Workout previews now reset previous workout progress and settings.

* **Bug Fixes**
  * Prevented invalid elapsed-time values from affecting workout guidance.
  * Added an option to show workout progress without announcing notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->