### PR TITLE
Disable markup to the workout list rows

### DIFF
--- a/src/fitness_tracker/ui_mode.py
+++ b/src/fitness_tracker/ui_mode.py
@@ -393,6 +393,7 @@ class ModeSelectView(Gtk.Box):
         # repopulate
         for workout, _ in self._entries:
             row = Adw.ActionRow()
+            row.set_use_markup(False)
             row.set_title(workout.name)
 
             # Workout information


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workout titles containing special characters now display correctly without being interpreted as formatting markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->