### PR TITLE
fix: launch Pebble app only during sessions

### DIFF
--- a/src/fitness_tracker/ui/app.py
+++ b/src/fitness_tracker/ui/app.py
@@ -383,7 +383,7 @@ class FitnessAppUI(Adw.Application):
         self.send_notification("workout-complete", notification)
 
     def apply_pebble_settings(self) -> None:
-        """Start, update, or stop the Pebble bridge for current settings."""
+        """Configure, update, or stop the Pebble bridge for current settings."""
         if self.pebble_bridge:
             # Skip teardown and recreation if no settings change
             if (
@@ -423,7 +423,6 @@ class FitnessAppUI(Adw.Application):
                 port=self.app_settings.pebble.port,
             )
 
-            self.pebble_bridge.start()
             self.pebble_bridge.update(
                 units=int(self.unit_system == UnitSystem.IMPERIAL),
             )

--- a/src/fitness_tracker/ui/app.py
+++ b/src/fitness_tracker/ui/app.py
@@ -197,7 +197,7 @@ class FitnessAppUI(Adw.Application):
                     self._reconcile_shutdown_finalization(recorder)
         if self.pebble_bridge:
             with contextlib.suppress(Exception):
-                self.pebble_bridge.stop()
+                self.pebble_bridge.stop(wait=False)
 
     def _on_close_request(self, *_a: object) -> bool:
         """Request application termination when the main window closes."""
@@ -400,7 +400,7 @@ class FitnessAppUI(Adw.Application):
                 return
 
             with contextlib.suppress(Exception):
-                self.pebble_bridge.stop()
+                self.pebble_bridge.stop(wait=False)
         self.pebble_bridge = None
 
         if not self.app_settings.pebble.enable:

--- a/src/fitness_tracker/ui/app.py
+++ b/src/fitness_tracker/ui/app.py
@@ -384,6 +384,9 @@ class FitnessAppUI(Adw.Application):
 
     def apply_pebble_settings(self) -> None:
         """Configure, update, or stop the Pebble bridge for current settings."""
+        tracker = self.__dict__.get("tracker")
+        recording_active = tracker is not None and tracker.recording_active
+
         if self.pebble_bridge:
             # Skip teardown and recreation if no settings change
             if (
@@ -426,6 +429,8 @@ class FitnessAppUI(Adw.Application):
             self.pebble_bridge.update(
                 units=int(self.unit_system == UnitSystem.IMPERIAL),
             )
+            if recording_active:
+                self.pebble_bridge.start()
         except Exception as e:
             self.pebble_bridge = None
             logger.error(e)

--- a/src/fitness_tracker/ui/pages/settings/page.py
+++ b/src/fitness_tracker/ui/pages/settings/page.py
@@ -585,7 +585,7 @@ class SettingsPageUI:
         self.app.refresh_hr_zones()
         self._update_actions_state()
 
-        # Apply Pebble settings right away (start/stop bridge without restart)
+        # Apply Pebble settings right away without restarting the application.
         _idle_once(self.app.apply_pebble_settings)
 
         # Keep the active session's recorder profile stable. The saved sensor

--- a/src/fitness_tracker/ui/pages/tracker.py
+++ b/src/fitness_tracker/ui/pages/tracker.py
@@ -149,6 +149,11 @@ class TrackerPageUI:
         """Return whether a session page currently owns the recorder profile."""
         return self.session_view is not None and self._session_state is not None
 
+    @property
+    def recording_active(self) -> bool:
+        """Return whether a session is currently recording or paused."""
+        return self._session_state in (SessionState.RUNNING, SessionState.PAUSED)
+
     def _start_workout(
         self,
         workout: Workout,

--- a/src/fitness_tracker/ui/pages/tracker.py
+++ b/src/fitness_tracker/ui/pages/tracker.py
@@ -471,6 +471,12 @@ class TrackerPageUI:
             self.app.show_toast(f"Unable to start recording: {error}")
             return
 
+        # Keep the watchapp closed while this page is only previewing. The
+        # bridge is configured at app startup, but its worker (and app launch)
+        # begin only after recording has actually started.
+        if self.app.pebble_bridge:
+            self.app.pebble_bridge.start()
+
         if self._workout_session:
             self._workout_session.distance_accumulator.reset()
         self._session_state = SessionState.RUNNING
@@ -503,6 +509,9 @@ class TrackerPageUI:
             # Always tear down UI session state, even if the trainer rejects zero load.
             self._session_state = None
             self._start_requested = False
+
+            if self.app.pebble_bridge:
+                self.app.pebble_bridge.stop()
 
             if self._timer_source_id is not None:
                 GLib.source_remove(self._timer_source_id)

--- a/src/fitness_tracker/ui/pages/tracker.py
+++ b/src/fitness_tracker/ui/pages/tracker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import time
 from collections import deque
 from typing import TYPE_CHECKING
@@ -480,7 +481,8 @@ class TrackerPageUI:
         # bridge is configured at app startup, but its worker (and app launch)
         # begin only after recording has actually started.
         if self.app.pebble_bridge:
-            self.app.pebble_bridge.start()
+            with contextlib.suppress(Exception):
+                self.app.pebble_bridge.start()
 
         if self._workout_session:
             self._workout_session.distance_accumulator.reset()
@@ -516,7 +518,8 @@ class TrackerPageUI:
             self._start_requested = False
 
             if self.app.pebble_bridge:
-                self.app.pebble_bridge.stop()
+                with contextlib.suppress(Exception):
+                    self.app.pebble_bridge.stop(wait=False)
 
             if self._timer_source_id is not None:
                 GLib.source_remove(self._timer_source_id)

--- a/src/pebble_bridge/pebble_bridge.py
+++ b/src/pebble_bridge/pebble_bridge.py
@@ -11,6 +11,7 @@ from libpebble2.communication import PebbleConnection
 from libpebble2.communication.transports.qemu import QemuTransport
 from libpebble2.communication.transports.serial import SerialTransport
 from libpebble2.communication.transports.websocket import WebsocketTransport
+from libpebble2.protocol.apps import AppRunState, AppRunStateStart, AppRunStateStop
 from libpebble2.services.appmessage import AppMessageService, Uint8, Uint16, Uint32
 from loguru import logger
 
@@ -141,13 +142,30 @@ class _CobbleBackend:
         await client.connect(require_daemon=True)
         self._client = client
         client.on_app_message(self._handle_app_message)
-        # Bring the watchapp to the foreground; an app that isn't running just
-        # NACKs every AppMessage. Best-effort: it may already be open.
-        try:
-            await self._client.launch_app(self._app_uuid)
-            await asyncio.sleep(1.0)
-        except Exception as e:
-            logger.debug(f"daemon launch_app failed (app may already be open): {e!r}")
+
+    async def _async_launch_app(self) -> None:
+        client = self._client
+        if client is None:
+            msg = "daemon backend not connected"
+            raise RuntimeError(msg)
+        await client.launch_app(self._app_uuid)
+        # Give the watchapp time to finish opening before the first AppMessage.
+        await asyncio.sleep(1.0)
+
+    def launch_app(self) -> None:
+        """Bring the configured watchapp to the foreground."""
+        self._call(self._async_launch_app(), timeout=self._connect_timeout + 10.0)
+
+    async def _async_stop_app(self) -> None:
+        client = self._client
+        if client is None:
+            msg = "daemon backend not connected"
+            raise RuntimeError(msg)
+        await client.stop_app(self._app_uuid)
+
+    def stop_app(self) -> None:
+        """Ask the daemon to close the configured watchapp."""
+        self._call(self._async_stop_app(), timeout=self._connect_timeout)
 
     def _handle_app_message(self, app_uuid: str, data: dict[int, object]) -> None:
         value = data.get(KEY_SYNC_REQUEST)
@@ -294,6 +312,30 @@ class _Libpebble2Backend:
     def _handle_nack(self, transaction_id: int, _app_uuid: UUID | None) -> None:
         self._record_delivery(transaction_id, acknowledged=False)
 
+    def launch_app(self) -> None:
+        """Bring the configured watchapp to the foreground."""
+        conn = self._conn
+        if conn is None:
+            msg = f"{self.name} backend not connected"
+            raise RuntimeError(msg)
+        conn.send_packet(
+            AppRunState(
+                data=AppRunStateStart(uuid=UUID(self._app_uuid)),
+            ),
+        )
+
+    def stop_app(self) -> None:
+        """Ask the watch to close the configured watchapp."""
+        conn = self._conn
+        if conn is None:
+            msg = f"{self.name} backend not connected"
+            raise RuntimeError(msg)
+        conn.send_packet(
+            AppRunState(
+                data=AppRunStateStop(uuid=UUID(self._app_uuid)),
+            ),
+        )
+
     def send(self, data: dict) -> None:
         appmsg = self._appmsg
         if appmsg is None:
@@ -367,7 +409,7 @@ class PebbleBridge:
         self._backend: _CobbleBackend | _Libpebble2Backend | None = None
 
     def start(self) -> None:
-        """Start the background thread to send updates."""
+        """Start the session bridge and bring the watchapp to the foreground."""
         mode = "Emulator" if self.use_emulator else "Watch"
         logger.debug(f"Starting pebble bridge ({mode})")
         self._running = True
@@ -375,10 +417,10 @@ class PebbleBridge:
         self._t.start()
 
     def stop(self) -> None:
-        """Stop the background thread and disconnect."""
+        """Close the watchapp, stop the background thread, and disconnect."""
         self._running = False
         self._wake.set()
-        self._close_backend()
+        self._close_backend(stop_app=True)
         thread = self._t
         if thread:
             thread.join(timeout=1.0)
@@ -536,9 +578,26 @@ class PebbleBridge:
         self._backend = backend
         logger.success("Connected to Pebble over Bluetooth serial")
 
-    def _close_backend(self) -> None:
+    def _launch_app(self) -> None:
+        backend = self._backend
+        if backend is None:
+            return
+        backend.launch_app()
+
+    def _connect_and_launch(self) -> None:
+        """Connect and launch unless stop was requested during connection."""
+        self._connect()
+        if self._running:
+            self._launch_app()
+
+    def _close_backend(self, *, stop_app: bool = False) -> None:
         backend, self._backend = self._backend, None
         if backend:
+            if stop_app:
+                try:
+                    backend.stop_app()
+                except Exception as e:
+                    logger.debug(f"Pebble app close error: {e!r}")
             try:
                 backend.close()
             except Exception as e:
@@ -579,7 +638,9 @@ class PebbleBridge:
             while self._running:
                 try:
                     if not self._backend:
-                        self._connect()
+                        # AppMessages sent to a stopped watchapp are rejected;
+                        # launch it only after the session bridge is started.
+                        self._connect_and_launch()
                         full_after_reconnect = True
                         backoff = 1.0
                     # Re-check after a (possibly slow) connect: if stop() fired
@@ -606,4 +667,4 @@ class PebbleBridge:
                         self._wake.clear()
                     backoff = min(10.0, backoff * 2)
         finally:
-            self._close_backend()
+            self._close_backend(stop_app=not self._running)

--- a/src/pebble_bridge/pebble_bridge.py
+++ b/src/pebble_bridge/pebble_bridge.py
@@ -66,6 +66,9 @@ def _target_wire_value(value: float, kind: int | None) -> int:
     return round(value * scale)
 
 
+_CURRENT_WORKER = object()
+
+
 class _CobbleBackend:
     """cobble_client transport: send via the shared cobbled daemon.
 
@@ -436,21 +439,33 @@ class PebbleBridge:
             )
             self._t.start()
 
-    def stop(self) -> None:
+    def stop(self, *, wait: bool = True) -> None:
         """Close the watchapp, stop the background thread, and disconnect."""
         with self._lifecycle_lock:
             self._running = False
-            if self._worker_stop_event is not None:
-                self._worker_stop_event.set()
+            stop_owner = self._worker_stop_event
+            if stop_owner is not None:
+                stop_owner.set()
             thread = self._t
         self._wake.set()
-        self._close_backend(stop_app=True)
-        if thread:
-            thread.join(timeout=1.0)
-            if not thread.is_alive():
-                with self._lifecycle_lock:
-                    if self._t is thread:
-                        self._t = None
+
+        def teardown() -> None:
+            self._close_backend(stop_app=True, expected_owner=stop_owner)
+            if thread:
+                thread.join(timeout=1.0)
+                if not thread.is_alive():
+                    with self._lifecycle_lock:
+                        if self._t is thread:
+                            self._t = None
+
+        if wait:
+            teardown()
+        else:
+            threading.Thread(
+                target=teardown,
+                name="pebble-bridge-stop",
+                daemon=True,
+            ).start()
 
     def _update_metrics(
         self,
@@ -571,25 +586,44 @@ class PebbleBridge:
                 return None
             return self._backend
 
+    def _close_backend_instance(
+        self,
+        backend: _CobbleBackend | _Libpebble2Backend,
+        *,
+        stop_app: bool = False,
+    ) -> None:
+        if stop_app:
+            try:
+                backend.stop_app()
+            except Exception as e:
+                logger.debug(f"Pebble app close error: {e!r}")
+        try:
+            backend.close()
+        except Exception as e:
+            logger.error(f"PebbleBridge close error: {e!r}")
+
     def _install_backend(
         self,
         backend: _CobbleBackend | _Libpebble2Backend,
         connection_message: str,
     ) -> None:
         owner = self._worker_owner()
+        previous: _CobbleBackend | _Libpebble2Backend | None = None
         with self._lifecycle_lock:
             active = owner is None or not owner.is_set()
             if active:
+                previous = self._backend
                 self._backend = backend
                 self._backend_owner = owner
         if active:
             logger.success(connection_message)
+            if previous is not None and previous is not backend:
+                self._close_backend_instance(previous, stop_app=True)
             return
-        with contextlib.suppress(Exception):
-            backend.close()
+        self._close_backend_instance(backend)
 
     def _connect(self) -> None:
-        if self._backend:
+        if self._backend_for_worker() is not None:
             logger.debug("Already connected")
             return
 
@@ -649,23 +683,23 @@ class PebbleBridge:
         if self._worker_is_active():
             self._launch_app()
 
-    def _close_backend(self, *, stop_app: bool = False) -> None:
+    def _close_backend(
+        self,
+        *,
+        stop_app: bool = False,
+        expected_owner: object = _CURRENT_WORKER,
+    ) -> None:
         owner = self._worker_owner()
         with self._lifecycle_lock:
-            if owner is not None and self._backend_owner is not owner:
+            if expected_owner is _CURRENT_WORKER:
+                if owner is not None and self._backend_owner is not owner:
+                    return
+            elif self._backend_owner is not expected_owner:
                 return
             backend, self._backend = self._backend, None
             self._backend_owner = None
         if backend:
-            if stop_app:
-                try:
-                    backend.stop_app()
-                except Exception as e:
-                    logger.debug(f"Pebble app close error: {e!r}")
-            try:
-                backend.close()
-            except Exception as e:
-                logger.error(f"PebbleBridge close error: {e!r}")
+            self._close_backend_instance(backend, stop_app=stop_app)
 
     def _send_once(self, *, full: bool = False) -> None:
         with self._lock:
@@ -702,7 +736,7 @@ class PebbleBridge:
         try:
             while self._worker_is_active():
                 try:
-                    if not self._backend:
+                    if self._backend_for_worker() is None:
                         # AppMessages sent to a stopped watchapp are rejected;
                         # launch it only after the session bridge is started.
                         self._connect_and_launch()

--- a/src/pebble_bridge/pebble_bridge.py
+++ b/src/pebble_bridge/pebble_bridge.py
@@ -400,6 +400,8 @@ class PebbleBridge:
         self.use_emulator = use_emulator
         self.port = port
         self._lock = threading.Lock()
+        self._lifecycle_lock = threading.Lock()
+        self._worker_context = threading.local()
         self._wake = threading.Event()
         self._state: dict[int, int] = {}  # latest metrics, key -> plain int
         self._dirty_keys: set[int] = set()
@@ -407,25 +409,48 @@ class PebbleBridge:
         self._running = False
         self._t: threading.Thread | None = None
         self._backend: _CobbleBackend | _Libpebble2Backend | None = None
+        self._backend_owner: threading.Event | None = None
+        self._worker_stop_event: threading.Event | None = None
 
     def start(self) -> None:
         """Start the session bridge and bring the watchapp to the foreground."""
         mode = "Emulator" if self.use_emulator else "Watch"
         logger.debug(f"Starting pebble bridge ({mode})")
-        self._running = True
-        self._t = threading.Thread(target=self._loop, daemon=True)
-        self._t.start()
+        with self._lifecycle_lock:
+            previous = self._t
+            if (
+                previous is not None
+                and previous.is_alive()
+                and self._worker_stop_event is not None
+                and not self._worker_stop_event.is_set()
+            ):
+                logger.debug("Pebble bridge is already running")
+                return
+            stop_event = threading.Event()
+            self._worker_stop_event = stop_event
+            self._running = True
+            self._t = threading.Thread(
+                target=self._loop,
+                args=(stop_event,),
+                daemon=True,
+            )
+            self._t.start()
 
     def stop(self) -> None:
         """Close the watchapp, stop the background thread, and disconnect."""
-        self._running = False
+        with self._lifecycle_lock:
+            self._running = False
+            if self._worker_stop_event is not None:
+                self._worker_stop_event.set()
+            thread = self._t
         self._wake.set()
         self._close_backend(stop_app=True)
-        thread = self._t
         if thread:
             thread.join(timeout=1.0)
             if not thread.is_alive():
-                self._t = None
+                with self._lifecycle_lock:
+                    if self._t is thread:
+                        self._t = None
 
     def _update_metrics(
         self,
@@ -526,6 +551,43 @@ class PebbleBridge:
             self._dirty_keys.add(key)
         self._state[key] = value
 
+    def _worker_owner(self) -> threading.Event | None:
+        return getattr(self._worker_context, "stop_event", None)
+
+    def _worker_is_active(self) -> bool:
+        stop_event = self._worker_owner()
+        if stop_event is not None:
+            return not stop_event.is_set()
+        return self._running
+
+    def _backend_for_worker(
+        self,
+    ) -> _CobbleBackend | _Libpebble2Backend | None:
+        owner = self._worker_owner()
+        with self._lifecycle_lock:
+            if self._backend is None:
+                return None
+            if owner is not None and self._backend_owner is not owner:
+                return None
+            return self._backend
+
+    def _install_backend(
+        self,
+        backend: _CobbleBackend | _Libpebble2Backend,
+        connection_message: str,
+    ) -> None:
+        owner = self._worker_owner()
+        with self._lifecycle_lock:
+            active = owner is None or not owner.is_set()
+            if active:
+                self._backend = backend
+                self._backend_owner = owner
+        if active:
+            logger.success(connection_message)
+            return
+        with contextlib.suppress(Exception):
+            backend.close()
+
     def _connect(self) -> None:
         if self._backend:
             logger.debug("Already connected")
@@ -540,8 +602,7 @@ class PebbleBridge:
                 port=self.port,
             )
             backend.connect()
-            self._backend = backend
-            logger.success("Connected to Pebble (emulator)")
+            self._install_backend(backend, "Connected to Pebble (emulator)")
             return
 
         if not self.mac:
@@ -564,8 +625,7 @@ class PebbleBridge:
                 backend.close()
 
             else:
-                self._backend = backend
-                logger.success("Connected to Pebble via cobbled daemon")
+                self._install_backend(backend, "Connected to Pebble via cobbled daemon")
                 return
         else:
             logger.debug(
@@ -575,11 +635,10 @@ class PebbleBridge:
         # 2. Serial fallback (libpebble2).
         backend = _Libpebble2Backend(self.app_uuid, self._on_app_message, mac=self.mac)
         backend.connect()
-        self._backend = backend
-        logger.success("Connected to Pebble over Bluetooth serial")
+        self._install_backend(backend, "Connected to Pebble over Bluetooth serial")
 
     def _launch_app(self) -> None:
-        backend = self._backend
+        backend = self._backend_for_worker()
         if backend is None:
             return
         backend.launch_app()
@@ -587,11 +646,16 @@ class PebbleBridge:
     def _connect_and_launch(self) -> None:
         """Connect and launch unless stop was requested during connection."""
         self._connect()
-        if self._running:
+        if self._worker_is_active():
             self._launch_app()
 
     def _close_backend(self, *, stop_app: bool = False) -> None:
-        backend, self._backend = self._backend, None
+        owner = self._worker_owner()
+        with self._lifecycle_lock:
+            if owner is not None and self._backend_owner is not owner:
+                return
+            backend, self._backend = self._backend, None
+            self._backend_owner = None
         if backend:
             if stop_app:
                 try:
@@ -613,7 +677,7 @@ class PebbleBridge:
             if not payload:
                 return
 
-        backend = self._backend
+        backend = self._backend_for_worker()
         if not backend:
             return
 
@@ -631,11 +695,12 @@ class PebbleBridge:
                 if self._state.get(key) == value:
                     self._dirty_keys.discard(key)
 
-    def _loop(self) -> None:
+    def _loop(self, stop_event: threading.Event | None = None) -> None:
+        self._worker_context.stop_event = stop_event
         backoff = 1.0
         full_after_reconnect = False
         try:
-            while self._running:
+            while self._worker_is_active():
                 try:
                     if not self._backend:
                         # AppMessages sent to a stopped watchapp are rejected;
@@ -645,7 +710,7 @@ class PebbleBridge:
                         backoff = 1.0
                     # Re-check after a (possibly slow) connect: if stop() fired
                     # while we were connecting, don't push a final stale frame.
-                    if not self._running:
+                    if not self._worker_is_active():
                         break
                     with self._lock:
                         request_id = self._full_request_id
@@ -655,11 +720,11 @@ class PebbleBridge:
                             if self._full_request_id == request_id:
                                 self._full_request_id = 0
                     full_after_reconnect = False
-                    if self._running:
+                    if self._worker_is_active():
                         self._wake.wait(0.5)
                         self._wake.clear()
                 except Exception as e:
-                    if not self._running:
+                    if not self._worker_is_active():
                         break
                     logger.error(f"PebbleBridge error: {e!r}")
                     self._close_backend()
@@ -667,4 +732,4 @@ class PebbleBridge:
                         self._wake.clear()
                     backoff = min(10.0, backoff * 2)
         finally:
-            self._close_backend(stop_app=not self._running)
+            self._close_backend(stop_app=not self._worker_is_active())

--- a/tests/test_pebble_protocol.py
+++ b/tests/test_pebble_protocol.py
@@ -51,6 +51,7 @@ class _Backend:
         self.closed = threading.Event()
         self.launched = threading.Event()
         self.stopped = threading.Event()
+        self.calls: list[str] = []
         self.int_types = {
             width: (lambda value, width=width: (width, value)) for width in (8, 16, 32)
         }
@@ -63,12 +64,14 @@ class _Backend:
         self.messages.append(message)
 
     def close(self) -> None:
+        self.calls.append("close")
         self.closed.set()
 
     def launch_app(self) -> None:
         self.launched.set()
 
     def stop_app(self) -> None:
+        self.calls.append("stop_app")
         self.stopped.set()
 
 
@@ -536,6 +539,50 @@ def test_stop_during_connect_closes_late_backend() -> None:
     assert backend.closed.is_set()
 
 
+def test_restart_during_blocked_connect_isolated_from_late_old_worker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge = PebbleBridge(
+        "00000000-0000-0000-0000-000000000000",
+        mac="AA:BB:CC:DD:EE:FF",
+    )
+    bridge.update(hr=140)
+    old_backend = _Backend()
+    new_backend = _Backend()
+    first_connect_started = threading.Event()
+    release_first_connect = threading.Event()
+    second_connect_started = threading.Event()
+    connect_count = 0
+
+    def connect() -> None:
+        nonlocal connect_count
+        connect_count += 1
+        if connect_count == 1:
+            first_connect_started.set()
+            release_first_connect.wait(timeout=2.0)
+            bridge._install_backend(old_backend, "old backend")
+            return
+        second_connect_started.set()
+        bridge._install_backend(new_backend, "new backend")
+
+    monkeypatch.setattr(bridge, "_connect", connect)
+    bridge.start()
+
+    assert first_connect_started.wait(timeout=1.0)
+    bridge.stop()
+    bridge.start()
+
+    assert second_connect_started.wait(timeout=1.0)
+    assert new_backend.launched.wait(timeout=1.0)
+    assert not old_backend.launched.is_set()
+
+    release_first_connect.set()
+    assert old_backend.closed.wait(timeout=1.0)
+    assert bridge._backend is new_backend
+
+    bridge.stop()
+
+
 def test_reconnect_requests_a_full_state_resend(monkeypatch: pytest.MonkeyPatch) -> None:
     bridge = PebbleBridge(
         "00000000-0000-0000-0000-000000000000",
@@ -576,6 +623,7 @@ def test_stop_requests_app_close_before_backend_disconnect() -> None:
 
     assert backend.stopped.is_set()
     assert backend.closed.is_set()
+    assert backend.calls.index("stop_app") < backend.calls.index("close")
 
 
 def test_watch_launch_requests_a_full_state_resend(

--- a/tests/test_pebble_protocol.py
+++ b/tests/test_pebble_protocol.py
@@ -559,7 +559,7 @@ def test_restart_during_blocked_connect_isolated_from_late_old_worker(
         connect_count += 1
         if connect_count == 1:
             first_connect_started.set()
-            release_first_connect.wait(timeout=2.0)
+            release_first_connect.wait(timeout=5.0)
             bridge._install_backend(old_backend, "old backend")
             return
         second_connect_started.set()
@@ -624,6 +624,34 @@ def test_stop_requests_app_close_before_backend_disconnect() -> None:
     assert backend.stopped.is_set()
     assert backend.closed.is_set()
     assert backend.calls.index("stop_app") < backend.calls.index("close")
+
+
+def test_nonblocking_stop_runs_backend_teardown_off_caller_thread(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge, backend = _bridge_with_backend()
+    teardown_started = threading.Event()
+    release_teardown = threading.Event()
+    teardown_thread_ids: list[int] = []
+
+    def stop_app() -> None:
+        teardown_thread_ids.append(threading.get_ident())
+        teardown_started.set()
+        release_teardown.wait(timeout=2.0)
+        backend.stopped.set()
+
+    monkeypatch.setattr(backend, "stop_app", stop_app)
+    bridge._running = True
+    caller_thread_id = threading.get_ident()
+
+    bridge.stop(wait=False)
+    try:
+        assert teardown_started.wait(timeout=1.0)
+        assert teardown_thread_ids[0] != caller_thread_id
+        assert not backend.closed.is_set()
+    finally:
+        release_teardown.set()
+        assert backend.closed.wait(timeout=1.0)
 
 
 def test_watch_launch_requests_a_full_state_resend(

--- a/tests/test_pebble_protocol.py
+++ b/tests/test_pebble_protocol.py
@@ -49,6 +49,8 @@ class _Backend:
         self.messages: list[dict[int, tuple[int, int]]] = []
         self.fail_next = False
         self.closed = threading.Event()
+        self.launched = threading.Event()
+        self.stopped = threading.Event()
         self.int_types = {
             width: (lambda value, width=width: (width, value)) for width in (8, 16, 32)
         }
@@ -62,6 +64,12 @@ class _Backend:
 
     def close(self) -> None:
         self.closed.set()
+
+    def launch_app(self) -> None:
+        self.launched.set()
+
+    def stop_app(self) -> None:
+        self.stopped.set()
 
 
 class _LibpebbleAppMessage:
@@ -252,6 +260,30 @@ def _libpebble_backend() -> tuple[pebble_module._Libpebble2Backend, _LibpebbleAp
     backend._appmsg = appmessage
     backend._send_timeout = 0.1
     return backend, appmessage
+
+
+def test_libpebble2_launch_and_stop_use_app_run_state_packets() -> None:
+    class _Connection:
+        def __init__(self) -> None:
+            self.packets: list[object] = []
+
+        def send_packet(self, packet: object) -> None:
+            self.packets.append(packet)
+
+    backend = pebble_module._Libpebble2Backend(
+        "f4fcdac7-f58e-4d22-96bd-48cf98e25d09",
+        lambda _app_uuid, _data: None,
+    )
+    connection = _Connection()
+    backend._conn = connection
+
+    backend.launch_app()
+    backend.stop_app()
+
+    assert [packet.serialise_packet().hex() for packet in connection.packets] == [
+        "0011003401f4fcdac7f58e4d2296bd48cf98e25d09",
+        "0011003402f4fcdac7f58e4d2296bd48cf98e25d09",
+    ]
 
 
 def test_libpebble2_send_waits_for_ack() -> None:
@@ -500,6 +532,7 @@ def test_stop_during_connect_closes_late_backend() -> None:
     allow_connect.set()
     worker.join(timeout=2.0)
     assert not worker.is_alive()
+    assert not backend.launched.is_set()
     assert backend.closed.is_set()
 
 
@@ -527,11 +560,22 @@ def test_reconnect_requests_a_full_state_resend(monkeypatch: pytest.MonkeyPatch)
     bridge._loop()
 
     assert calls == [True]
+    assert backend.launched.is_set()
     assert set(_sent_values(backend)) == {
         pebble_module.KEY_HR,
         pebble_module.KEY_PACE,
         pebble_module.KEY_CADENCE,
     }
+
+
+def test_stop_requests_app_close_before_backend_disconnect() -> None:
+    bridge, backend = _bridge_with_backend()
+    bridge._running = True
+
+    bridge.stop()
+
+    assert backend.stopped.is_set()
+    assert backend.closed.is_set()
 
 
 def test_watch_launch_requests_a_full_state_resend(

--- a/tests/test_ui_sensor_lifecycle.py
+++ b/tests/test_ui_sensor_lifecycle.py
@@ -233,6 +233,31 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
 
         self.assertEqual(pebble_steps, [0])
 
+    def test_changed_pebble_settings_restart_bridge_for_active_recording(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        old_bridge = Mock(mac="old", use_emulator=True, port=1234)
+        replacement = Mock()
+        app.pebble_bridge = old_bridge
+        app.tracker = types.SimpleNamespace(recording_active=True)
+        app.app_settings = types.SimpleNamespace(
+            display=types.SimpleNamespace(unit_system=None),
+            pebble=types.SimpleNamespace(
+                address="new",
+                enable=True,
+                port=5678,
+                use_emulator=True,
+                uuid="test-uuid",
+            ),
+        )
+
+        with patch("fitness_tracker.ui.app.PebbleBridge", return_value=replacement):
+            app.apply_pebble_settings()
+
+        old_bridge.stop.assert_called_once_with()
+        replacement.update.assert_called_once_with(units=0)
+        replacement.start.assert_called_once_with()
+        self.assertIs(app.pebble_bridge, replacement)
+
     def test_workout_complete_uses_toast_and_desktop_notification(self):
         app = FitnessAppUI.__new__(FitnessAppUI)
         toasts = []

--- a/tests/test_ui_sensor_lifecycle.py
+++ b/tests/test_ui_sensor_lifecycle.py
@@ -253,9 +253,34 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
         with patch("fitness_tracker.ui.app.PebbleBridge", return_value=replacement):
             app.apply_pebble_settings()
 
-        old_bridge.stop.assert_called_once_with()
+        old_bridge.stop.assert_called_once_with(wait=False)
         replacement.update.assert_called_once_with(units=0)
         replacement.start.assert_called_once_with()
+        self.assertIs(app.pebble_bridge, replacement)
+
+    def test_changed_pebble_settings_keep_bridge_stopped_when_recording_inactive(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        old_bridge = Mock(mac="old", use_emulator=True, port=1234)
+        replacement = Mock()
+        app.pebble_bridge = old_bridge
+        app.tracker = types.SimpleNamespace(recording_active=False)
+        app.app_settings = types.SimpleNamespace(
+            display=types.SimpleNamespace(unit_system=None),
+            pebble=types.SimpleNamespace(
+                address="new",
+                enable=True,
+                port=5678,
+                use_emulator=True,
+                uuid="test-uuid",
+            ),
+        )
+
+        with patch("fitness_tracker.ui.app.PebbleBridge", return_value=replacement):
+            app.apply_pebble_settings()
+
+        old_bridge.stop.assert_called_once_with(wait=False)
+        replacement.update.assert_called_once_with(units=0)
+        replacement.start.assert_not_called()
         self.assertIs(app.pebble_bridge, replacement)
 
     def test_workout_complete_uses_toast_and_desktop_notification(self):


### PR DESCRIPTION
closes #216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- The Pebble app now launches automatically when workout recording starts.
- The Pebble app closes when recording ends.
- Pebble settings apply immediately without restarting the application.
- Improved reconnect behavior keeps the Pebble app running and synchronized.

## Bug Fixes
- Prevented the Pebble app from launching after recording has already stopped.
- Improved reliability when restarting recording or replacing Pebble settings during an active or paused session.
- Improved shutdown handling to prevent stale connections and delayed updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->