### PR TITLE
Notify workout changes only in background

### DIFF
--- a/src/fitness_tracker/ui/app.py
+++ b/src/fitness_tracker/ui/app.py
@@ -370,17 +370,35 @@ class FitnessAppUI(Adw.Application):
 
         title = f"Workout step {step_number} of {step_count}"
         self.show_toast(f"{title}: {target_text}")
-        notification = Gio.Notification.new(title)
-        notification.set_body(target_text)
-        self.send_notification("workout-step-change", notification)
+        self._send_background_notification(
+            "workout-step-change",
+            title,
+            target_text,
+        )
 
     def show_workout_complete_notification(self) -> None:
-        """Show in-app and desktop notifications when a workout completes."""
+        """Announce completion in-app and, when unfocused, on the desktop."""
         message = "✅ Workout complete. Continuing in Free Run…"
         self.show_toast(message)
-        notification = Gio.Notification.new("Workout complete")
-        notification.set_body("Continuing in Free Run")
-        self.send_notification("workout-complete", notification)
+        self._send_background_notification(
+            "workout-complete",
+            "Workout complete",
+            "Continuing in Free Run",
+        )
+
+    def _send_background_notification(
+        self,
+        notification_id: str,
+        title: str,
+        body: str,
+    ) -> None:
+        """Send a desktop notification only when the main window is not active."""
+        if self.window is not None and self.window.is_active():
+            return
+
+        notification = Gio.Notification.new(title)
+        notification.set_body(body)
+        self.send_notification(notification_id, notification)
 
     def apply_pebble_settings(self) -> None:
         """Configure, update, or stop the Pebble bridge for current settings."""

--- a/tests/test_ui_sensor_lifecycle.py
+++ b/tests/test_ui_sensor_lifecycle.py
@@ -206,6 +206,7 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
         app.send_notification = lambda notification_id, notification: notifications.append(
             (notification_id, notification),
         )
+        app.window = types.SimpleNamespace(is_active=lambda: False)
         app.pebble_bridge = types.SimpleNamespace(
             update=lambda **values: pebble_steps.append(values["workout_step"]),
         )
@@ -232,6 +233,24 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
         app.show_workout_step_notification(1, 5, "Target: 100 W", announce=False)
 
         self.assertEqual(pebble_steps, [0])
+
+    def test_workout_step_desktop_notification_is_suppressed_in_foreground(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        toasts = []
+        pebble_steps = []
+        app.window = types.SimpleNamespace(is_active=lambda: True)
+        app.show_toast = toasts.append
+        app.send_notification = lambda *_args: self.fail(
+            "Foreground step change should not send a desktop notification",
+        )
+        app.pebble_bridge = types.SimpleNamespace(
+            update=lambda **values: pebble_steps.append(values["workout_step"]),
+        )
+
+        app.show_workout_step_notification(2, 5, "Target: 150 - 175 W")
+
+        self.assertEqual(pebble_steps, [1])
+        self.assertEqual(toasts, ["Workout step 2 of 5: Target: 150 - 175 W"])
 
     def test_changed_pebble_settings_restart_bridge_for_active_recording(self):
         app = FitnessAppUI.__new__(FitnessAppUI)
@@ -291,6 +310,7 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
         app.send_notification = lambda notification_id, notification: notifications.append(
             (notification_id, notification),
         )
+        app.window = types.SimpleNamespace(is_active=lambda: False)
 
         app.show_workout_complete_notification()
 
@@ -298,6 +318,19 @@ class SensorSettingsLifecycleTests(unittest.TestCase):
         self.assertEqual(notifications[0][0], "workout-complete")
         self.assertEqual(notifications[0][1].title, "Workout complete")
         self.assertEqual(notifications[0][1].body, "Continuing in Free Run")
+
+    def test_workout_complete_desktop_notification_is_suppressed_in_foreground(self):
+        app = FitnessAppUI.__new__(FitnessAppUI)
+        toasts = []
+        app.window = types.SimpleNamespace(is_active=lambda: True)
+        app.show_toast = toasts.append
+        app.send_notification = lambda *_args: self.fail(
+            "Foreground completion should not send a desktop notification",
+        )
+
+        app.show_workout_complete_notification()
+
+        self.assertEqual(toasts, ["✅ Workout complete. Continuing in Free Run…"])
 
     def test_pending_finalization_toast_retries_and_refreshes_history(self):
         app = FitnessAppUI.__new__(FitnessAppUI)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop notifications are now suppressed while the app window is active.
  * In-app toast notifications continue to appear for workout steps and completion.
  * Pebble updates remain available throughout workouts.

* **Tests**
  * Added coverage for notification behavior when the app is in the foreground.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->