### PR TITLE
Throttle live chart redraws to 1 Hz

### DIFF
--- a/src/fitness_tracker/ui/pages/session.py
+++ b/src/fitness_tracker/ui/pages/session.py
@@ -423,7 +423,7 @@ class SessionView(Gtk.Box):
         pw: np.ndarray,
         hr_rgb: tuple[float, float, float] = (1, 1, 1),
     ) -> None:
-        """Update the continuous session chart."""
+        """Update chart data; the tracker controls the redraw cadence."""
         self.live_chart.line_hr.set_data(x_secs, hr)
         self.live_chart.line_pw.set_data(x_secs, pw)
         self.live_chart.line_hr.set_color(hr_rgb)
@@ -434,7 +434,6 @@ class SessionView(Gtk.Box):
             self.live_chart.power_axes.set_ylim(max(0.0, pmin - pad), pmax + pad)
         else:
             self.live_chart.power_axes.set_ylim(0, 500)
-        self.live_chart.canvas.draw_idle()
 
     def refresh_theme(self) -> None:
         """Restyle the continuous chart without discarding its data."""

--- a/src/fitness_tracker/ui/pages/tracker.py
+++ b/src/fitness_tracker/ui/pages/tracker.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 TGT_NONE = 0
 _UI_UPDATE_INTERVAL_MS = 500  # 2 Hz
 _UI_UPDATE_INTERVAL_S = _UI_UPDATE_INTERVAL_MS / 1000.0
+_CHART_UPDATE_INTERVAL_MS = 1000  # 1 Hz; Matplotlib redraws are intentionally slower
 
 
 class TrackerPageUI:
@@ -101,6 +102,7 @@ class TrackerPageUI:
 
         # status updater
         self._status_timer_id: int | None = None
+        self._chart_timer_id: int | None = None
 
         # workout state
         self._workout_session: (
@@ -265,6 +267,22 @@ class TrackerPageUI:
 
         return True
 
+    def _start_chart_timer(self) -> None:
+        """Start the lower-frequency chart redraw timer for an open session."""
+        if self._chart_timer_id is None:
+            self._chart_timer_id = GLib.timeout_add(
+                _CHART_UPDATE_INTERVAL_MS,
+                self._tick_chart,
+            )
+
+    def _tick_chart(self) -> bool:
+        """Redraw the chart independently of the 2 Hz metric updates."""
+        if self._session_state is None or self.session_view is None:
+            self._chart_timer_id = None
+            return False
+        self.session_view.redraw()
+        return True
+
     # -------------------------
     #  Page show / run control
     # -------------------------
@@ -332,6 +350,7 @@ class TrackerPageUI:
             workout=False,
         )
         self.session_view = view
+        self._start_chart_timer()
         self._push(self.session_view, title)
 
         self.app.apply_sensor_settings(
@@ -378,6 +397,7 @@ class TrackerPageUI:
             workout=True,
         )
         self.session_view = view
+        self._start_chart_timer()
         if self.app.pebble_bridge:
             self.app.pebble_bridge.update(
                 workout_outdoor=environment is Environment.OUTDOOR,
@@ -527,6 +547,9 @@ class TrackerPageUI:
             if self._timer_source_id is not None:
                 GLib.source_remove(self._timer_source_id)
                 self._timer_source_id = None
+            if self._chart_timer_id is not None:
+                GLib.source_remove(self._chart_timer_id)
+                self._chart_timer_id = None
 
         # Always stop recording after attempting trainer neutralization.
         if recorder:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Chart redraws are now scheduled separately from general interface updates, improving display responsiveness and consistency during active sessions.
  * Charts continue updating while free-run and workout sessions are open and stop cleanly when sessions end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->