### PR TITLE
Add failed upload history filter

### DIFF
--- a/src/fitness_tracker/data/repositories.py
+++ b/src/fitness_tracker/data/repositories.py
@@ -69,6 +69,10 @@ class ActivityRepository(Protocol):
         """List activity summaries, optionally restricted to a start-time cutoff."""
         ...
 
+    def list_failed_activity_stats(self) -> list[ActivityStatsRow]:
+        """List activity summaries with at least one failed upload."""
+        ...
+
     def list_heart_rates(self, activity_id: int) -> list[HeartRate]:
         """List heart-rate samples ordered by sample time."""
         ...
@@ -163,6 +167,18 @@ class SqlAlchemyActivityRepository:
         )
         if cutoff is not None:
             statement = statement.where(ActivityStats.start_time >= cutoff)
+        with self._session_factory() as session:
+            return list(session.scalars(statement).all())
+
+    def list_failed_activity_stats(self) -> list[ActivityStatsRow]:
+        """List activity summaries with at least one failed upload."""
+        failed_activity_ids = select(ActivityUpload.activity_id).where(
+            ActivityUpload.status == "failed",
+        )
+        statement = select(ActivityStats).where(
+            ActivityStats.sport_type_id != SportTypesEnum.unknown.value,
+            ActivityStats.activity_id.in_(failed_activity_ids),
+        )
         with self._session_factory() as session:
             return list(session.scalars(statement).all())
 

--- a/src/fitness_tracker/ui/pages/history.py
+++ b/src/fitness_tracker/ui/pages/history.py
@@ -196,6 +196,7 @@ class HistoryPageUI:
         self.filter_combo.append("week", "Last 7 Days")
         self.filter_combo.append("month", "Last 30 Days")
         self.filter_combo.append("all", "All Time")
+        self.filter_combo.append("failed", "Failed Uploads")
         self.filter_combo.set_active_id(self.filter_id)
         self.filter_combo.connect("changed", self._on_filter_changed)
 
@@ -397,6 +398,9 @@ class HistoryPageUI:
     def _fetch_stats_rows(self, filter_id: str | None = None) -> list[ActivityStatsRow]:
         """Single SELECT against activity_stats with optional cutoff filter."""
         repository = self._get_repository()
+        selected_filter = self.filter_id if filter_id is None else filter_id
+        if selected_filter == "failed":
+            return repository.list_failed_activity_stats()
         cutoff = self._filter_cutoff(filter_id)
         # The repository compares the stored UTC value with the local-aware cutoff.
         return repository.list_activity_stats(cutoff)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -778,6 +778,23 @@ def test_concurrent_upload_updates_share_one_provider_row(tmp_path: Path) -> Non
     assert uploads[0].payload_hash is not None
 
 
+def test_failed_activity_stats_excludes_pending_and_successful_uploads(tmp_path: Path) -> None:
+    db = _manager(tmp_path / "database.db")
+    failed_id = db.start_activity(SportTypesEnum.running, Environment.INDOOR)
+    successful_id = db.start_activity(SportTypesEnum.running, Environment.INDOOR)
+    pending_id = db.start_activity(SportTypesEnum.running, Environment.INDOOR)
+    for activity_id in (failed_id, successful_id, pending_id):
+        db.finalize_activity(activity_id)
+
+    db.repository.mark_upload_failed(failed_id, PROVIDER, "network unavailable")
+    db.repository.mark_upload_failed(failed_id, "another_provider", "service unavailable")
+    db.repository.mark_upload_ok(successful_id, PROVIDER)
+
+    rows = db.repository.list_failed_activity_stats()
+
+    assert [row.activity_id for row in rows] == [failed_id]
+
+
 def test_older_failure_does_not_overwrite_newer_success(tmp_path: Path) -> None:
     db = _manager(tmp_path / "database.db")
     activity_id = db.start_activity(SportTypesEnum.running, Environment.INDOOR)

--- a/tests/test_ui_review_fixes.py
+++ b/tests/test_ui_review_fixes.py
@@ -119,6 +119,20 @@ def test_history_activity_title_can_shrink_in_narrow_layout() -> None:
     title.set_ellipsize.assert_called_once_with(history_module.Pango.EllipsizeMode.END)
 
 
+def test_history_failed_filter_queries_only_failed_upload_stats() -> None:
+    page = HistoryPageUI.__new__(HistoryPageUI)
+    repository = Mock()
+    repository.list_failed_activity_stats.return_value = [SimpleNamespace(activity_id=7)]
+    page.filter_id = "failed"
+    page._get_repository = Mock(return_value=repository)
+
+    rows = page._fetch_stats_rows()
+
+    assert [row.activity_id for row in rows] == [7]
+    repository.list_failed_activity_stats.assert_called_once_with()
+    repository.list_activity_stats.assert_not_called()
+
+
 def test_history_backfill_discard_and_duplicate_release_reload_guard() -> None:
     page = HistoryPageUI.__new__(HistoryPageUI)
     jobs = Mock()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Failed Uploads** filter to activity history.
  - Failed Uploads now displays activities with upload failures across providers.
  - Activities with successful or pending uploads are excluded.

- **Bug Fixes**
  - Improved failed-upload history filtering to show accurate results.

- **Tests**
  - Added coverage for synchronization and failed-history filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->